### PR TITLE
Get phpunit from the phar download instead of apt

### DIFF
--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -34,4 +34,7 @@
 - name: Fix the stdin bug, step 2
   lineinfile: dest=/root/.profile line="tty -s && mesg n"
 
+- name: Get PHPUnit
+  get_url: url=https://phar.phpunit.de/phpunit.phar dest=/usr/local/bin/phpunit mode=0755 validate_certs=no
+
 - include: swap.yml

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Uninstall deprecated packages or ones we don't want anymore
+  apt: name={{ item }} state=absent purge=yes
+  with_items:
+    - phpunit
+
 - name: Install necessary packages for proper system state
   apt: name={{ item }} state=latest
   with_items:

--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -10,7 +10,6 @@
       - php5-memcache
       - php5-memcached
       - php5-xdebug
-      - phpunit
 
 # - name: Do fpm/php.ini
 #   template: src=etc/php5/fpm/php.ini dest=/etc/php5/fpm/php.ini owner=root group=root mode=0644


### PR DESCRIPTION
The correct way to install phpunit is from phar not using apt-get.  That method is deprecated.

The only risk is these tasks don't remove the existing phpunit from apt before installing it from the phar.  So, existing vagrants that have it install from apt, then run this will have a conflict and the side effect will be the wrong (3.7.x) will be in use.

 - [ ] @zamoose 
 - [x] @markkelnar