### PR TITLE
Turn off nginx sendfile due to VirtualBox bug

### DIFF
--- a/provisioning/roles/nginx/templates/etc/nginx/nginx.conf
+++ b/provisioning/roles/nginx/templates/etc/nginx/nginx.conf
@@ -13,7 +13,7 @@ http {
 	# Basic Settings
 	##
 
-	sendfile on;
+	sendfile off;
 	tcp_nopush on;
 	tcp_nodelay on;
 	keepalive_timeout 65;


### PR DESCRIPTION
VirtualBox shared folders have a bug that means guest webservers,
including Apache and nginx, should have sendfile functionality turned
off.  See http://docs.vagrantup.com/v2/synced-folders/virtualbox.html
for details and links to the associated bug reports.

* [x] @markkelnar 
* [x] @zamoose