### PR TITLE
WordPress extract domain from tasks

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -12,8 +12,17 @@
     - nginx
     - wp-cli
     - varnish
-    - { role: wordpress, enviro: php, domain: "php.hgv.dev", tags: [ 'wordpress' ] }
-    - { role: wordpress, enviro: hhvm, domain: "hhvm.hgv.dev", tags: [ 'wordpress' ] }
+    - { 
+        role: wordpress, 
+        enviro: php, 
+        domain: "php.hgv.dev",
+        tags: [ 'wordpress' ] 
+      }
+    - { role: wordpress,
+        enviro: hhvm,
+        domain: "hhvm.hgv.dev",
+        tags: [ 'wordpress' ]
+      }
     - admin
     - xhprof
 

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -12,7 +12,8 @@
     - nginx
     - wp-cli
     - varnish
-    - { role: wordpress, enviro: php, tags: [ 'wordpress' ] }
-    - { role: wordpress, enviro: hhvm, tags: [ 'wordpress' ] }
+    - { role: wordpress, enviro: php, domain: "php.hgv.dev", tags: [ 'wordpress' ] }
+    - { role: wordpress, enviro: hhvm, domain: "hhvm.hgv.dev", tags: [ 'wordpress' ] }
     - admin
     - xhprof
+

--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -46,7 +46,7 @@
   template: src=wp/object-cache.php dest={{ wp_doc_root }}/{{ enviro }}/wp-content/object-cache.php owner={{ web_user }} group={{ web_group }}
 
 - name: "Run the WP install for {{ enviro }}"
-  command: /usr/local/bin/wp core install --url={{ enviro }}.hgv.dev --title="WP Engine {{ enviro }} Site" --admin_user=wordpress --admin_password=wordpress --admin_email="admin@example.com"
+  command: /usr/local/bin/wp core install --url={{ domain }} --title="WP Engine {{ enviro }} Site" --admin_user=wordpress --admin_password=wordpress --admin_email="admin@example.com"
   sudo: yes
   sudo_user: "{{ web_user }}"
   args:

--- a/provisioning/roles/wordpress/templates/etc/nginx/wordpress.conf
+++ b/provisioning/roles/wordpress/templates/etc/nginx/wordpress.conf
@@ -1,12 +1,12 @@
 server {
 	listen       80;
-	server_name  {{ enviro }}.hgv.dev;
+	server_name  {{ domain }};
 	root {{ wp_doc_root }}/{{ enviro }};
 
 	index index.php;
-	access_log  /var/log/nginx/{{ enviro }}.hgv.dev.access.log  wpengine;
-	access_log  /var/log/nginx/{{ enviro }}.hgv.dev.apachestyle.access.log  apachestandard;
-	error_log  /var/log/nginx/{{ enviro }}.hgv.dev.error.log warn;
+	access_log  /var/log/nginx/{{ domain }}.access.log  wpengine;
+	access_log  /var/log/nginx/{{ domain }}.apachestyle.access.log  apachestandard;
+	error_log  /var/log/nginx/{{ domain }}.error.log warn;
 
 	# WordPress single blog rules.
 	# Designed to be included in any server {} block.

--- a/provisioning/roles/wordpress/templates/etc/nginx/wpcache.conf
+++ b/provisioning/roles/wordpress/templates/etc/nginx/wpcache.conf
@@ -1,12 +1,12 @@
 server {
         listen          80;
-        server_name     cache.{{ enviro }}.hgv.dev;
+        server_name     cache.{{ domain }};
         root            {{ wp_doc_root }}/{{ enviro }};
 
         index index.php;
-        access_log  /var/log/nginx/cache.{{ enviro }}.hgv.dev.access.log  wpengine;
-        access_log  /var/log/nginx/cache.{{ enviro }}.hgv.dev.apachestyle.access.log  apachestandard;
-        error_log  /var/log/nginx/cache.{{ enviro }}.hgv.dev.error.log warn;
+        access_log  /var/log/nginx/cache.{{ domain }}.access.log  wpengine;
+        access_log  /var/log/nginx/cache.{{ domain }}.apachestyle.access.log  apachestandard;
+        error_log  /var/log/nginx/cache.{{ domain }}.error.log warn;
 
         location / {
                 proxy_set_header X-WP-ENVIRO "{{ enviro }}";

--- a/provisioning/roles/wordpress/templates/wp/local-config.php
+++ b/provisioning/roles/wordpress/templates/wp/local-config.php
@@ -32,8 +32,8 @@ $memcached_servers = array(
 );
 
 if( isset($_SERVER['HTTP_HOST']) && 'cache.' === substr( $_SERVER['HTTP_HOST'], 0, 6) ){
-    define('WP_SITEURL', 'http://cache.{{ enviro }}.hgv.dev');
-    define('WP_HOME', 'http://cache.{{ enviro }}.hgv.dev');
+    define('WP_SITEURL', 'http://cache.{{ domain }}');
+    define('WP_HOME', 'http://cache.{{ domain }}');
     define('WP_CACHE_KEY_SALT', 'cache_wpe_{{ enviro }}_1');
 }else{
     define('WP_CACHE_KEY_SALT', 'wpe_{{ enviro }}_1');

--- a/provisioning/roles/wordpress/templates/wp/local-config.php
+++ b/provisioning/roles/wordpress/templates/wp/local-config.php
@@ -32,8 +32,8 @@ $memcached_servers = array(
 );
 
 if( isset($_SERVER['HTTP_HOST']) && 'cache.' === substr( $_SERVER['HTTP_HOST'], 0, 6) ){
-    define('WP_SITEURL', 'http://cache.{{ domain }}');
-    define('WP_HOME', 'http://cache.{{ domain }}');
+    define('WP_SITEURL', 'http://'.$_SERVER['HTTP_HOST']);
+    define('WP_HOME', 'http://'.$_SERVER['HTTP_HOST']);
     define('WP_CACHE_KEY_SALT', 'cache_wpe_{{ enviro }}_1');
 }else{
     define('WP_CACHE_KEY_SALT', 'wpe_{{ enviro }}_1');


### PR DESCRIPTION
Taking a stab at extracting our default domains (*.hgv.dev) and enviroment docroot from the tasks and templates.  The idea it to rework the tasks and roles a bit to be able to add custom domains from another variable (or yaml file or somewhere) and also combine the WordPress for HHVM and PHP-FPM under a single docroot if desired.  Consider this round one.

Related to
https://github.com/wpengine/hgv/issues/7
https://github.com/wpengine/hgv/issues/15
https://github.com/wpengine/hgv/issues/16

 - [x] @markkelnar
 - [x] @zamoose 