### PR TITLE
Set user/group/perms for yaml.ini. Idempodent tweak for php5enmod

### DIFF
--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -22,10 +22,10 @@
     - yaml
 
 - name: Register YAML module
-  lineinfile: state=present create=yes dest=/etc/php5/mods-available/yaml.ini line="extension=yaml.so"
+  lineinfile: state=present create=yes dest=/etc/php5/mods-available/yaml.ini line="extension=yaml.so" owner=root group=root mode=0644
 
 - name: Enable YAML module
-  command: php5enmod yaml
+  command: php5enmod yaml creates=/etc/php5/fpm/conf.d/20-yaml.ini
 
 # - name: Do fpm/php.ini
 #   template: src=etc/php5/fpm/php.ini dest=/etc/php5/fpm/php.ini owner=root group=root mode=0644


### PR DESCRIPTION
Running a command line php script as user 'vagrant', yaml_parse_file() was no accessible.  This change fixes that access.

This change also does not run php5enmod if the yaml module symlink is already present and therefore enabled.

 - [x] @markkelnar
 - [x] @zamoose 