### PR TITLE
Split the line into two lines and priorities

### DIFF
--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -1,4 +1,5 @@
-# Getting Started with Mercury Vagrant (HGV)#
+# Mercury Vagrant (HGV) #
+### Getting Started ###
 This project is intended as a tool for allowing WP Engine users to test their code prior to actual deployment on WP Engine "Mercury" infrastructure. This is not intended as an *exact* replica of WP Engine's infrastructure, but is instead a "simulator" of the conditions and software stack on WPE's Mercury platform, allowing you to develop and test your code with an end goal of stability and compatibility with Mercury.
 
 Mercury differs from standard WordPress hosting in several ways, chief among which is the use of HHVM to serve all PHP code.


### PR DESCRIPTION
This is my attempt at fixing the visual run over of the top header in the HGV admin dashboard.
Fixes the cramped looking text in the left side navigation too.

Fix to https://github.com/wpengine/hgv/issues/64

@stephen-lin What do you think?  Or do you prefer the CSS fix as suggested here https://github.com/wpengine/hgv/pull/65 ?

 - [x] @markkelnar
 - [ ] @zamoose 
![screen shot 2015-02-02 at 5 06 16 pm](https://cloud.githubusercontent.com/assets/749603/6011107/0c22f894-aafe-11e4-99bb-950f003a2c0c.png)