### PR TITLE
Add new domain that shares the hhvm WP install but processed by FPM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,8 +30,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.hostsupdater.aliases = [
             "hhvm.hgv.dev",
             "php.hgv.dev",
+            "fpm.hgv.dev",
             "cache.hhvm.hgv.dev",
             "cache.php.hgv.dev",
+            "cache.fpm.hgv.dev",
             "admin.hgv.dev",
             "xhprof.hgv.dev"
         ]

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -28,6 +28,14 @@
         tags: [ 'wordpress' ]
       }
     - {
+        role: listener,
+        enviro: hhvm,
+        backend: php,
+        # All the domains to listen on for this backend
+        domain: "fpm.hgv.dev",
+        tags: [ 'wordpress' ]
+      }
+    - {
         role: wordpress,
         enviro: php,
         # Primary domain, used to setup WP SITEURL/HOME


### PR DESCRIPTION
Add a new domain (fpm.hgv.dev) that uses the existing WP that resides under /nas/wp/www/sites/hhvm but is processed by the backend PHP-FPM.  This is a step towards consolidating the use into one default WP.

https://github.com/wpengine/hgv/issues/16

I did not change any documentation highlighting this change.

 - [x] @markkelnar
 - [x] @stephen-lin 