### PR TITLE
Enable php module when not enabled already

### DIFF
--- a/provisioning/roles/xhprof/tasks/main.yml
+++ b/provisioning/roles/xhprof/tasks/main.yml
@@ -4,7 +4,7 @@
   tags: [ 'profiling', 'xhprof' ]
 
 - name: Enable xhprof
-  command: php5enmod xhprof
+  command: php5enmod xhprof creates=/etc/php5/fpm/conf.d/20-xhprof.ini
   notify: php5-fpm restart
   tags: [ 'profiling', 'xhprof' ]
 


### PR DESCRIPTION
The symlink is created when the module is enabled.  Only run the command when that file does not exist.

 - [x] @markkelnar
 - [x] @zamoose 