### PR TITLE
Pass more params to fastcgi when come from varnish

### DIFF
--- a/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
+++ b/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
@@ -34,12 +34,11 @@ server {
 		# Enable for xhprof tracing
 		fastcgi_param PHP_VALUE "auto_prepend_file={{ xhprof_root }}/external/header.php \n auto_append_file={{ xhprof_root }}/external/footer.php";
 
-		try_files $uri =404;
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
 		fastcgi_pass {{ backend }};
 		fastcgi_intercept_errors on;
 		fastcgi_index index.php;
-		fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		include fastcgi_params;
 	}
 }

--- a/provisioning/roles/nginx/templates/etc/nginx/conf.d/upstream.conf
+++ b/provisioning/roles/nginx/templates/etc/nginx/conf.d/upstream.conf
@@ -33,6 +33,11 @@ server {
         }
 
         location ~ \.php$ {
+		fastcgi_split_path_info ^(.+\.php)(/.+)$;
                 fastcgi_pass $http_x_upstream_target;
+		fastcgi_intercept_errors on;
+		fastcgi_index index.php;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		include fastcgi_params;
         }
 }

--- a/provisioning/roles/nginx/templates/etc/nginx/conf.d/upstream.conf
+++ b/provisioning/roles/nginx/templates/etc/nginx/conf.d/upstream.conf
@@ -29,7 +29,7 @@ server {
         index index.php;
 
         location / {
-                try_files $uri $uri/ /index.php?$args =404;
+                try_files $uri $uri/ /index.php?$args;
         }
 
         location ~ \.php$ {


### PR DESCRIPTION
This is my fix to https://github.com/wpengine/hgv/issues/53.

Not all the parameters were making it to fastcgi after coming to Nginx from Varnish.

 - [x] @markkelnar
 - [x] @zamoose 