### PR TITLE
Set up Mailhog

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             "cache.php.hgv.dev",
             "cache.fpm.hgv.dev",
             "admin.hgv.dev",
-            "xhprof.hgv.dev"
+            "xhprof.hgv.dev",
+            "mail.hgv.dev"
         ]
     end
 

--- a/provisioning/roles/admin/defaults/main.yml
+++ b/provisioning/roles/admin/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+mailhog_binary_url: https://github.com/mailhog/MailHog/releases/download/v0.1.5/MailHog_linux_amd64
+mailhog_install_dir: /opt/mailhog
+
+ssmtp_mailhub: localhost:1025
+ssmtp_root: postmaster
+ssmtp_authuser: ""
+ssmtp_authpass: ""
+ssmtp_from_line_override: "YES"

--- a/provisioning/roles/admin/files/etc/nginx/conf.d/mail.conf
+++ b/provisioning/roles/admin/files/etc/nginx/conf.d/mail.conf
@@ -1,0 +1,17 @@
+server {
+        listen          80;
+        server_name     mail.hgv.dev;
+
+        access_log  /var/log/nginx/mail.hgv.dev.access.log  wpengine;
+        access_log  /var/log/nginx/mail.hgv.dev.apachestyle.access.log  apachestandard;
+        error_log  /var/log/nginx/mail.hgv.dev.error.log warn;
+
+        location / {
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+                proxy_pass http://127.0.0.1:8025;
+        }
+
+}

--- a/provisioning/roles/admin/files/mailhog_init
+++ b/provisioning/roles/admin/files/mailhog_init
@@ -1,0 +1,60 @@
+#! /bin/sh
+# /etc/init.d/mailhog
+#
+# MailHog init script.
+#
+# @author Jeff Geerling
+
+### BEGIN INIT INFO
+# Provides:          mailhog
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start MailHog at boot time.
+# Description:       Enable MailHog.
+### END INIT INFO
+
+PID=/var/run/mailhog.pid
+LOCK=/var/lock/mailhog.lock
+USER=nobody
+BIN=/opt/mailhog/mailhog
+
+# Carry out specific functions when asked to by the system
+case "$1" in
+  start)
+    echo "Starting mailhog."
+    daemonize -p $PID -l $LOCK -u $USER $BIN
+    ;;
+  stop)
+    if [ -f $PID ]; then
+      echo "Stopping mailhog.";
+      kill -TERM $(cat $PID);
+      rm -f $PID;
+    else
+      echo "MailHog is not running.";
+    fi
+    ;;
+  restart)
+    echo "Restarting mailhog."
+    if [ -f $PID ]; then
+      kill -TERM $(cat $PID);
+      rm -f $PID;
+    fi
+    daemonize -p $PID -l $LOCK -u $USER $BIN
+    ;;
+  status)
+    if [ -f $PID ]; then
+      echo "MailHog is running.";
+    else
+      echo "MailHog is not running.";
+      exit 3
+    fi
+    ;;
+  *)
+    echo "Usage: /etc/init.d/mailhog {start|stop|status|restart}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/provisioning/roles/admin/tasks/main.yml
+++ b/provisioning/roles/admin/tasks/main.yml
@@ -12,6 +12,9 @@
   notify: nginx reload
   tags: [ 'admin' ]
 
+#
+# phpMyAdmin Setup
+#
 - name: Ensure phpMyAdmin directory exists
   file: path={{ wp_doc_root }}/admin/phpmyadmin state=directory owner={{ web_user }} group={{ web_group }}
   tags: [ 'admin', 'phpmyadmin' ]
@@ -32,6 +35,9 @@
   template: src=phpmyadminconfig.php dest={{ wp_doc_root }}/admin/phpmyadmin/config.inc.php group={{ web_group }} owner={{ web_user }}
   tags: ['admin', 'phpmyadmin' ]
 
+#
+# phpMemcachedAdmin setup
+#
 - name: Ensure phpMemcachedAdmin directory exists
   file: path={{ wp_doc_root }}/admin/phpmemcachedadmin state=directory owner={{ web_user }} group={{ web_group }}
   tags: [ 'admin', 'phpmemcachedadmin' ]
@@ -44,6 +50,9 @@
   unarchive: src=/tmp/phpMemcachedAdmin-{{ phpmemcachedadmin_version }}.zip dest={{ wp_doc_root }}/admin/phpmemcachedadmin copy=no owner={{ web_user }} group={{ web_group }}
   tags: [ 'admin', 'phpmemcachedadmin' ]
 
+#
+# PimpMyLogs setup
+#
 - name: Ensure PML directory exists
   file: path={{ wp_doc_root }}/admin/logs state=directory owner={{ web_user }} group={{ web_group }}
   tags: [ 'admin', 'pimpmylog' ]
@@ -55,3 +64,73 @@
 - name: Configure PML
   template: src=pimpmylog.config.user.php dest={{ wp_doc_root }}/admin/logs/config.user.php group={{ web_group }} owner={{ web_user }} mode=0444
   tags: [ 'admin', 'pimpmylog' ]
+
+#
+# MailHog setup
+#
+- name: Ensure mailhog directory exists
+  file:
+    path: "{{ mailhog_install_dir }}"
+    owner: root
+    group: root
+    state: directory
+    mode: 0755
+  tags: [ 'admin', 'mailhog' ]
+
+- name: Download MailHog
+  get_url:
+    url: "{{ mailhog_binary_url }}"
+    dest: "{{ mailhog_install_dir }}/mailhog"
+    owner: root
+    group: root
+    mode: 0755
+  tags: [ 'admin', 'mailhog' ]
+
+- name: Install mailhog init script
+  copy:
+    src: mailhog_init
+    dest: /etc/init.d/mailhog
+    owner: root
+    group: root
+    mode: 0755
+  tags: [ 'admin', 'mailhog' ]
+
+- name: Ensure mailhog is enabled and will start on boot.
+  service:
+    name: mailhog
+    state: started
+    enabled: yes
+  tags: [ 'admin', 'mailhog' ]
+
+- name: Install sSMTP.
+  apt: pkg=ssmtp state=installed
+  tags: [ 'admin', 'mailhog' ]
+
+- name: Copy sSMTP configuration.
+  template:
+    src: etc/ssmtp/ssmtp.conf
+    dest: /etc/ssmtp/ssmtp.conf
+    owner: root
+    group: root
+    mode: 0644
+  tags: [ 'admin', 'mailhog' ]
+
+- name: Set up Mailhog virtualhost
+  copy:
+    src: etc/nginx/conf.d/mail.conf
+    dest: /etc/nginx/conf.d/mail.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify: nginx reload
+  tags: [ 'admin', 'mailhog' ]
+
+- name: Set up PHP sendmail
+  ini_file:
+    dest: "{{ item }}"
+    section: "mail function"
+    option: sendmail_path
+    value: "/usr/sbin/ssmtp -t"
+  with_items:
+      - /etc/php5/fpm/php.ini
+      - /etc/php5/cli/php.ini

--- a/provisioning/roles/admin/templates/etc/ssmtp/ssmtp.conf
+++ b/provisioning/roles/admin/templates/etc/ssmtp/ssmtp.conf
@@ -1,0 +1,24 @@
+#
+# Config file for sSMTP sendmail
+#
+# The person who gets all mail for userids < 1000
+# Make this empty to disable rewriting.
+root={{ ssmtp_root }}
+
+# The place where the mail goes. The actual machine name is required no
+# MX records are consulted. Commonly mailhosts are named mail.domain.com
+mailhub={{ ssmtp_mailhub }}
+AuthUser={{ ssmtp_authuser }}
+AuthPass={{ ssmtp_authpass }}
+# TODO: Add UseTLS, UseSTARTTLS?
+
+# Where will the mail seem to come from?
+#rewriteDomain=
+
+# The full hostname
+hostname={{ inventory_hostname }}
+
+# Are users allowed to set their own From: address?
+# YES - Allow the user to specify their own From: address
+# NO - Use the system generated From: address
+FromLineOverride={{ ssmtp_from_line_override }}

--- a/provisioning/roles/common/defaults/main.yml
+++ b/provisioning/roles/common/defaults/main.yml
@@ -1,5 +1,3 @@
 ---
-d_workspace: /root
-
 daemonize_version: 1.7.5
 daemonize_install_path: "/usr"

--- a/provisioning/roles/common/defaults/main.yml
+++ b/provisioning/roles/common/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+d_workspace: /root
+
+daemonize_version: 1.7.5
+daemonize_install_path: "/usr"

--- a/provisioning/roles/common/tasks/daemonize.yml
+++ b/provisioning/roles/common/tasks/daemonize.yml
@@ -1,0 +1,29 @@
+---
+- name: Check if daemonize is installed.
+  command: which daemonize
+  changed_when: false
+  failed_when: false
+  register: daemonize_installed
+
+- name: Download daemonize source
+  get_url:
+    url: "https://github.com/bmc/daemonize/archive/release-{{ daemonize_version }}.tar.gz"
+    dest: "/tmp/daemonize-{{ daemonize_version }}.tar.gz"
+  when: daemonize_installed|failed
+
+- name: Expand daemonize source
+  command: >
+    tar -zxf /tmp/daemonize-{{ daemonize_version }}.tar.gz
+    chdir=/tmp
+    creates=/tmp/daemonize-release-{{ daemonize_version }}/INSTALL
+  when: daemonize_installed|failed
+
+- name: Compile daemonize
+  command: >
+    {{ item }}
+    chdir=/tmp/daemonize-release-{{ daemonize_version }}
+  when: daemonize_installed|failed
+  with_items:
+    - ./configure
+    - "make prefix={{ daemonize_install_path }}"
+    - "make prefix={{ daemonize_install_path }} install"

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -43,3 +43,4 @@
   get_url: url=https://phar.phpunit.de/phpunit.phar dest=/usr/local/bin/phpunit mode=0755 validate_certs=no
 
 - include: swap.yml
+- include: daemonize.yml

--- a/provisioning/roles/hhvm/templates/etc/hhvm/php.ini
+++ b/provisioning/roles/hhvm/templates/etc/hhvm/php.ini
@@ -8,3 +8,4 @@ hhvm.log.level = Warning
 hhvm.log.always_log_unhandled_exceptions = true
 hhvm.log.runtime_error_reporting_level = 8191
 hhvm.mysql.typed_results = false
+hhvm.mail.sendmail_path = /usr/sbin/ssmtp -t


### PR DESCRIPTION
In lieu of Mailcatcher, [this discussion](https://github.com/Varying-Vagrant-Vagrants/VVV/issues/337) over on the VVV issue tracker turned me on to [Mailhog](https://github.com/mailhog/MailHog). MH seems to work more reliably and it has storage of email that persists daemon restarts. It installs easier and cleaner than Mailcatcher and seems to be more recently updated.

This PR installs and configures MH and sets up PHP and HHVM to use MH instead of system mail. It borrows concepts and some manifest structures from [here](https://github.com/geerlingguy/ansible-role-mailhog).

Addresses #86.

* [x] @zamoose
* [x] @markkelnar  