### PR TITLE
Include my.cnf, bind to 0.0.0.0 instead of localhost to allow Sequel Pro to connect.

### DIFF
--- a/provisioning/roles/percona/tasks/main.yml
+++ b/provisioning/roles/percona/tasks/main.yml
@@ -3,10 +3,10 @@
   file: path=/etc/mysql state=directory owner=root group=root mode=0755
   tags: [ 'percona', 'database' ]
 
-# - name: ensure /etc/mysql/my.cnf ...
-#   template: src=etc/mysql/my.cnf dest=/etc/mysql/my.cnf owner=root group=root mode=0644
-#   notify:
-#     - mysql restart
+- name: ensure /etc/mysql/my.cnf ...
+  template: src=etc/mysql/my.cnf dest=/etc/mysql/my.cnf owner=root group=root mode=0644
+  notify:
+    - mysql restart
 
 - name: Install Percona GPG key
   apt_key: file=/vagrant/provisioning/roles/percona/templates/percona-gpg-key state=present
@@ -27,5 +27,13 @@
   apt: name=percona-server-client-5.6 state=present
   tags: [ 'percona', 'database' ]
 
+- name: Grant root user access
+  mysql_user:
+    name: root
+    priv: "*.*:ALL"
+    host: "%"
+    password: ""
+    state: present
+  tags: [ 'percona', 'database' ]
 #- name: Ensure Percona is running
 #  service: name=mysql state=started

--- a/provisioning/roles/percona/templates/etc/mysql/my.cnf
+++ b/provisioning/roles/percona/templates/etc/mysql/my.cnf
@@ -10,6 +10,7 @@ nice			= 0
 user			= mysql
 pid-file		= /var/run/mysqld/mysqld.pid
 socket			= /var/run/mysqld/mysqld.sock
+bind-address    = 0.0.0.0
 port			= 3306
 basedir			= /usr
 datadir			= /var/lib/mysql


### PR DESCRIPTION
* [x] @zamoose
* [x] @markkelnar 

Right now, Percona is only listening to 127.0.0.1. This causes e.g. #88. 

These fixes should apply cleanly and seem to work just fine in my tests, but validation would be great.