### PR TITLE
Add fix for hhvm using wrong mysql socket

### DIFF
--- a/provisioning/roles/hhvm/templates/etc/hhvm/php.ini
+++ b/provisioning/roles/hhvm/templates/etc/hhvm/php.ini
@@ -8,3 +8,8 @@ hhvm.log.level = Warning
 hhvm.log.always_log_unhandled_exceptions = true
 hhvm.log.runtime_error_reporting_level = 8191
 hhvm.mysql.typed_results = false
+
+; Bug fix for HHVM 3.6.0 talking to mysql socket (Remove when HHVM 3.6.1 is released?)
+hhvm.mysql.socket = /var/run/mysqld/mysqld.sock
+hhvm.pdo_mysql.socket = /var/run/mysqld/mysqld.sock
+hhvm.mysqli.socket = /var/run/mysqld/mysqld.sock


### PR DESCRIPTION
The symlink under /tmp/ worked, but did not survive a 'vagrant reload'.  I tested setting the socket path in the HHVM ini file and this works.

Fixes
https://github.com/wpengine/hgv/issues/100

- [x] @markkelnar
- [x] @zamoose 