### PR TITLE
Add php5-curl for curl.so

### DIFF
--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -5,6 +5,7 @@
   with_items:
       - php5
       - php5-cli
+      - php5-curl
       - php5-gd
       - php5-fpm
       - php5-memcache


### PR DESCRIPTION
Function curl_init() was not available in php5-fpm.  It's provided by package php5-curl.

The lib and enables the curl module.
/usr/lib/php5/20121212/curl.so
/etc/php5/fpm/conf.d/20-curl.ini

 - [x] @markkelnar
 - [x] @zamoose 