### PR TITLE
Set nginx FastCGI response buffer size

### DIFF
--- a/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
+++ b/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
@@ -40,5 +40,7 @@ server {
 		fastcgi_index index.php;
 		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
 		include fastcgi_params;
+		fastcgi_buffers 16 16k;
+		fastcgi_buffer_size 32k;
 	}
 }


### PR DESCRIPTION
* [x] @zamoose
* [x] @markkelnar 

### Problem

On the PHP-FPM version of the site, you will sometimes get an "upstream sent too big header" error; to the user, this will look like a 502 Bad Gateway error

### Solution

Setting FastCGI response buffer size.