### PR TITLE
Use command instead of service until we find the real reason

### DIFF
--- a/provisioning/roles/php-fpm/handlers/main.yml
+++ b/provisioning/roles/php-fpm/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: php5-fpm restart
-  service: name=php5-fpm state=restarted
+  command: service php5-fpm restart


### PR DESCRIPTION
Newer ansible versions don't like the php5-fpm service restart task.  Use this in the mean time until we can find the real problem.

https://github.com/wpengine/hgv/issues/141

Note: Ansible will throw a warning and suggestion to use the service command.
``` 
"Consider using service module rather than running service"