### PR TITLE
Remove the init.d in favor of upstart

### DIFF
--- a/provisioning/roles/php-fpm/handlers/main.yml
+++ b/provisioning/roles/php-fpm/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: php5-fpm restart
-  command: service php5-fpm restart
+  service: name=php5-fpm state=restarted

--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -45,3 +45,7 @@
 # - name: Do fpm/php.ini
 #   template: src=etc/php5/fpm/php.ini dest=/etc/php5/fpm/php.ini owner=root group=root mode=0644
 #   notify: php5-fpm restart
+
+- name: Remove FPM init.d script
+  file: path=/etc/init.d/php5-fpm state=absent
+  notify: php5-fpm restart


### PR DESCRIPTION
Another 'fix' or workaround for php5-fpm init.d failing when invoked by ansible.

Fix to https://github.com/wpengine/hgv/issues/141

Documentation, forums and testing shows that removing the init.d script, that gets layed down by the php5-fpm deb package, is the fix for the ansible service restart task.

We don't have to use this, just wanted to put it out here as an option.  Poking @zamoose thoughts since he also looked into it.