### PR TITLE
Upstart-friendly version of php5-fpm restart

### DIFF
--- a/provisioning/roles/php-fpm/handlers/main.yml
+++ b/provisioning/roles/php-fpm/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 
 - name: php5-fpm restart
-  command: service php5-fpm restart
+  command: restart php5-fpm

--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -35,6 +35,7 @@
     owner: root
     group: root
     mode: 0644
+  notify: php5-fpm restart
   tags: [ 'php' ]
 
 - name: Enable Xdebug module

--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -35,13 +35,13 @@
     owner: root
     group: root
     mode: 0644
-  notify: php5-fpm restart
   tags: [ 'php' ]
 
 - name: Enable Xdebug module
   command: php5enmod xdebug creates=/etc/php5/fpm/conf.d/20-xdebug.ini
+  notify: php5-fpm restart
   tags: [ 'php' ]
-  
+
 # - name: Do fpm/php.ini
 #   template: src=etc/php5/fpm/php.ini dest=/etc/php5/fpm/php.ini owner=root group=root mode=0644
 #   notify: php5-fpm restart


### PR DESCRIPTION
* [x] @zamoose
* [x] @markkelnar 

This should be a short-term fix, as we really ought to use the Ansible first-class entities wherever possible and thus should revert to using the `service` module as soon as upstream gets their act together.

Fixes #141, supplants #142.