### PR TITLE
Domains by variables

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,17 @@ dir = Dir.pwd
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
 vagrant_name = File.basename(dir)
 
+require 'yaml'
+
+domains_array = []
+
+# Load default domains 
+domains = YAML.load_file('./provisioning/default_sites.yml')
+domains['default_wp']['hhvm_domains'].each do |domain|
+    domains_array.push(domain)
+    domains_array.push('cache.' << domain)
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "ubuntu/trusty64"
     config.vm.hostname = "hgv.dev"
@@ -28,17 +39,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.synced_folder "./hgv_data", "/hgv_data", owner: "www-data", group: "www-data", create: "true"
 
     if defined? VagrantPlugins::HostsUpdater
-        config.hostsupdater.aliases = [
-            "hhvm.hgv.dev",
-            "php.hgv.dev",
-            "fpm.hgv.dev",
-            "cache.hhvm.hgv.dev",
-            "cache.php.hgv.dev",
-            "cache.fpm.hgv.dev",
-            "admin.hgv.dev",
-            "xhprof.hgv.dev",
-            "mail.hgv.dev"
-        ]
+        config.hostsupdater.aliases = domains_array
     end
 
     # This allows the git commands to work using host server keys

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,12 @@ domains['default_wp']['hhvm_domains'].each do |domain|
     domains_array.push(domain)
     domains_array.push('cache.' << domain)
 end
+unless domains['default_wp']['php_domains'].nil?
+    domains['default_wp']['php_domains'].each do |domain|
+        domains_array.push(domain)
+        domains_array.push('cache.' << domain)
+    end
+end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "ubuntu/trusty64"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,10 +10,10 @@ vagrant_name = File.basename(dir)
 
 require 'yaml'
 
-domains_array = []
+domains_array = ['admin.hgv.dev', 'xhprof.hgv.dev', 'mail.hgv.dev']
 
 # Load default domains 
-domains = YAML.load_file('./provisioning/default_sites.yml')
+domains = YAML.load_file('./provisioning/default-sites.yml')
 domains['default_wp']['hhvm_domains'].each do |domain|
     domains_array.push(domain)
     domains_array.push('cache.' << domain)

--- a/bin/hgv-init.sh
+++ b/bin/hgv-init.sh
@@ -51,6 +51,6 @@ chmod 644 /vagrant/provisioning/hosts
 export PYTHONUNBUFFERED=1
 
 # $ANS_BIN /vagrant/provisioning/playbook.yml -i /vagrant/provisioning/hosts
-$ANS_BIN /vagrant/provisioning/playbook.yml -i'127.0.0.1,'
+$ANS_BIN /vagrant/provisioning/playbook.yml -i'127.0.0.1,' --extra-vars="@/vagrant/provisioning/default-sites.yml"
 
 echo

--- a/provisioning/default-sites.yml
+++ b/provisioning/default-sites.yml
@@ -1,0 +1,5 @@
+---
+default_wp:
+  enviro: hhvm
+  hhvm_domains: [ 'hhvm.hgv.dev' ]
+  php_domains: [ 'fpm.hgv.dev' ]

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -14,32 +14,30 @@
     - varnish
     - {
         role: wordpress,
-        enviro: hhvm,
-        # Primary domain, used to setup WP SITEURL/HOME
-        domain: "hhvm.hgv.dev",
+        enviro: "{{ default_wp.enviro }}",
+        domain: "{{ default_wp.hhvm_domains[0] }}",
         tags: [ 'wordpress' ]
       }
     - {
         role: listener,
-        enviro: hhvm,
+        enviro: "{{ default_wp.enviro }}",
         backend: hhvm,
-        # All the domains to listen on for this backend
-        domain: "hhvm.hgv.dev",
-        tags: [ 'wordpress' ]
+        domain: "{{ default_wp.hhvm_domains }}",
+        tags: [ 'wordpress' ],
       }
     - {
         role: listener,
-        enviro: hhvm,
+        enviro: "{{ default_wp.enviro }}",
         backend: php,
-        # All the domains to listen on for this backend
-        domain: "fpm.hgv.dev",
-        tags: [ 'wordpress' ]
+        domain: "{{ default_wp.php_domains }}",
+        tags: [ 'wordpress' ],
+        when: default_wp.php_domains is defined
       }
     - {
         role: wordpress,
         enviro: php,
         # Primary domain, used to setup WP SITEURL/HOME
-        domain: "hhvm.hgv.dev",
+        domain: [ "php.hgv.dev" ],
         tags: [ 'wordpress' ]
       }
     - {
@@ -47,7 +45,7 @@
         enviro: php,
         backend: php,
         # All the domains to listen on for this backend
-        domain: "php.hgv.dev",
+        domain: [ "php.hgv.dev" ],
         tags: [ 'wordpress' ]
       }
     - admin

--- a/provisioning/roles/listener/tasks/main.yml
+++ b/provisioning/roles/listener/tasks/main.yml
@@ -8,3 +8,5 @@
 
 - name: "Enable PML viewing for {{ enviro }} {{ backend }}"
   template: src=pimpmylog.json dest={{ wp_doc_root }}/admin/logs/config.user.d/{{ enviro }}-{{ backend }}.json
+  with_items:
+    - "{{ domain }}"

--- a/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
+++ b/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
@@ -1,6 +1,6 @@
 server {
 	listen          80;
-	server_name     {{ domain }};
+	server_name     {% for i in domain %}{{ i }} {% endfor %};
 	root            {{ wp_doc_root }}/{{ enviro }};
 
 	index index.php;

--- a/provisioning/roles/listener/templates/etc/nginx/wpcache.conf
+++ b/provisioning/roles/listener/templates/etc/nginx/wpcache.conf
@@ -1,6 +1,6 @@
 server {
         listen          80;
-        server_name     cache.{{ domain }};
+	server_name     {% for i in domain %}cache.{{ i }} {% endfor %};
         root            {{ wp_doc_root }}/{{ enviro }};
 
         index index.php;

--- a/provisioning/roles/listener/templates/pimpmylog.json
+++ b/provisioning/roles/listener/templates/pimpmylog.json
@@ -1,4 +1,4 @@
-{"{{ domain }}1": {
+{"{{ item }}1": {
         "display" : "{{ enviro }} {{ backend }} Access Log",
         "path"    : "\/var\/log\/nginx\/{{ enviro }}-{{ backend }}.apachestyle.access.log",
         "refresh" : 0,
@@ -34,7 +34,7 @@
             }
         }
     },
-"{{ domain }}2": {
+"{{ item }}2": {
         "display" : "{{ enviro }} {{ backend }} Error Log",
         "path"    : "\/var\/log\/nginx\/{{ enviro }}-{{ backend }}.error.log",
         "refresh" : 0,


### PR DESCRIPTION
Here's my take of some things, and my own stab at custom domains.  

I stole/used some of code from @zamoose's the Vagrantfile Ruby stuff.  Tried to work in the direction of not building the dependency of file names and variable names further down into the ansible roles.

This supports existing default domains (hhvm.hgv.dev, fpm.hgv.dev, php.hgv.dev) that get created and doesn't change any behavior.

In a different PR/branch I have code to work on custom YML files directory and format and triggered by the bash init script.  

Again, explored some ideas to see what it would look like and even possible with variables and yml files in a conf.d/.  One change I didn't make here was the move of php.hgv.dev to point to the 'hhvm' WP install on disk.  That change doesn't have to happen with all these other changes, that's fairly easy to change next.

This will make it easy to add or change to the .local TLD for these installs.

* [ ] @zamoose
* [x] @markkelnar 

