### PR TITLE
Check wp-not-installed return code of the registered variable

### DIFF
--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -55,7 +55,7 @@
   sudo_user: "{{ web_user }}"
   args:
     chdir: "{{ wp_doc_root }}/{{ enviro }}"
-  when: wpnotinstalled
+  when: wpnotinstalled.rc
 
 - name: "Install some useful plugins for {{ enviro }}"
   command: /usr/local/bin/wp plugin install {{ item }}


### PR DESCRIPTION
* [x] @zamoose
* [x] @markkelnar 

In the wordpress role, the task 'Run the WP install for hhvm' always ran the 'wp-cli core install' command and after the WP exists, returns 'WordPress is already installed'.

This PR uses the return code 'rc' of the registered variable wpnotinstalled from task that checks if the WP is installed using 'wp-cli core is-installed'