### PR TITLE
Fix "not a tty" in a way that doesn't break `vagrant ssh`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,7 +45,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.ssh.forward_agent = true
 
     # To avoid stdin/tty issues
-    config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+    config.vm.provision "fix-no-tty", type: "shell" do |s|
+        s.privileged = false
+        s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+    end
 
     config.vm.provision "shell" do |s|
         s.path = "bin/hgv-init.sh"


### PR DESCRIPTION
* [x] @zamoose
* [x] @markkelnar

Fix this in a way that doesn't break `vagrant ssh`. Fixes #147.