### PR TITLE
Split site provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,9 @@ dir = Dir.pwd
 vagrant_dir = File.expand_path(File.dirname(__FILE__))
 vagrant_name = File.basename(dir)
 
+default_installs = vagrant_dir + '/provisioning/default-install.yml'
+custom_installs_dir = vagrant_dir + '/hgv_data/config'
+
 require 'yaml'
 
 domains_array = ['admin.hgv.dev', 'xhprof.hgv.dev', 'mail.hgv.dev']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,25 +18,29 @@ domains_array = ['admin.hgv.dev', 'xhprof.hgv.dev', 'mail.hgv.dev']
 def domains_from_yml(file)
     ret = []
     domains = YAML.load_file(file)
-    domains['wp']['hhvm_domains'].each do |domain|
-        ret.push(domain)
-        ret.push('cache.' << domain)
-    end
-    # php_domains are optional in the user specified file
-    unless domains['wp']['php_domains'].nil?
-        domains['wp']['php_domains'].each do |domain|
+    domains.each do |key, value|
+        # hhvm_domains are mandatory in user-supplied files
+        value['hhvm_domains'].each do |domain|
             ret.push(domain)
             ret.push('cache.' << domain)
         end
+        # php_domains are optional in the user specified file
+        unless value['php_domains'].nil?
+            value['php_domains'].each do |domain|
+                ret.push(domain)
+                ret.push('cache.' << domain)
+            end
+        end
     end
+
     return ret
 end
 
-# Load default domains 
-domains_array += domains_from_yml './provisioning/default-install.yml'
+# Load default domains
+domains_array += domains_from_yml(default_installs)
 # Load user specified domain file
-Dir.glob("./hgv_data/config/*.yml").each do |custom_file|
-    domains_array += domains_from_yml custom_file
+Dir.glob( custom_installs_dir + "/*.yml").each do |custom_file|
+    domains_array += domains_from_yml(custom_file)
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,8 +68,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
     end
 
+    # Default/base provisioning
     config.vm.provision "shell" do |s|
         s.path = "bin/hgv-init.sh"
         s.keep_color = true
     end
+
+    # Custom site provisioning
+    config.vm.provision "shell" do |s|
+        s.path = "bin/custom-sites.sh"
+        s.keep_color = true
+    end
+
 end

--- a/bin/custom-sites.sh
+++ b/bin/custom-sites.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+ANS_BIN=`which ansible-playbook`
+
+if [[ -z $ANS_BIN ]]
+    then
+    echo "Whoops, can't find Ansible anywhere. Aborting run."
+    echo
+    exit
+fi
+
+# More continuous scroll of the ansible standard output buffer
+export PYTHONUNBUFFERED=1
+export ANSIBLE_FORCE_COLOR=true
+
+shopt -s nullglob
+for file in /vagrant/provisioning/default-install.yml /vagrant/hgv_data/config/*.yml
+do
+    echo "### Provisioning $file ###"
+    $ANS_BIN /vagrant/provisioning/wordpress.yml -i'127.0.0.1,' --extra-vars="@$file"
+done
+
+echo

--- a/bin/hgv-init.sh
+++ b/bin/hgv-init.sh
@@ -53,11 +53,3 @@ export PYTHONUNBUFFERED=1
 export ANSIBLE_FORCE_COLOR=true
 
 $ANS_BIN /vagrant/provisioning/playbook.yml -i'127.0.0.1,'
-shopt -s nullglob
-for file in /vagrant/provisioning/default-install.yml /vagrant/hgv_data/config/*.yml
-do
-    echo "### Provisioning $file ###"
-    $ANS_BIN /vagrant/provisioning/wordpress.yml -i'127.0.0.1,' --extra-vars="@$file"
-done
-
-echo

--- a/bin/mac-linux-custom-sites.sh
+++ b/bin/mac-linux-custom-sites.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Provisioning custom sites."
+vagrant up
+vagrant ssh -c '/bin/bash /vagrant/bin/custom-sites.sh'


### PR DESCRIPTION
* [x] @zamoose
* [ ] @markkelnar 

Allow for easier site set-up without full `vagrant provision`/`vagrant up --provision` to make new site creation take a lot less time.

Essentially, add your new YAML file to `hgv_data/config` and run `vagrant up;vagrant ssh -c "/bin/sh /vagrant/bin/custom-sites.sh"`. This will add the new domains to the host OS via hostsupdater and provision the sites on the HGV side of things.