### PR TITLE
Explicitly mark wp-config.php as Ansible-managed.

### DIFF
--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -22,6 +22,12 @@
     path: "{{ wp_doc_root }}/{{ enviro }}/wp-config.php"
   register: wpconfig
 
+- name: Check whether {{ enviro }}/wp-config.php is Ansible-managed
+  command: /bin/grep '^* Ansible managed' {{ wp_doc_root }}/{{ enviro }}/wp-config.php
+  register: wpansmgd
+  ignore_errors: yes
+  when: wpconfig.stat.exists
+
 - name: Fetch random salts for WordPress config
   get_url:
     dest: "{{ wp_doc_root }}/{{ enviro }}/wp-salts.php"
@@ -40,6 +46,15 @@
     owner: "{{ web_user }}"
     group: "{{ web_group }}"
   when: not wpconfig.stat.exists
+
+- name: "Create new wp-config for {{ enviro }} and save original"
+  template:
+    src: wp/wp-config.php
+    dest: "{{ wp_doc_root }}/{{ enviro }}/wp-config.php"
+    owner: "{{ web_user }}"
+    group: "{{ web_group }}"
+    backup: yes
+  when: wpconfig.stat.exists and wpansmgd|failed
 
 - name: "Localconfig for {{ enviro }}"
   template: src=wp/local-config.php dest={{ wp_doc_root }}/{{ enviro }}/local-config.php owner={{ web_user }} group={{ web_group }}

--- a/provisioning/roles/wordpress/templates/wp/wp-config.php
+++ b/provisioning/roles/wordpress/templates/wp/wp-config.php
@@ -1,5 +1,6 @@
 <?php
 /**
+* {{ ansible_managed }}
 * The base configurations of the WordPress.
 *
 * This file has the following configurations: MySQL settings, Table Prefix,


### PR DESCRIPTION
* [x] @zamoose
* [x] @markkelnar 

If the managed string isn't detected, re-template the file and save a backup copy.

Fixes #156.