### PR TITLE
Force Windows to use Samba for file shares

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.vm.synced_folder "./hgv_data", "/hgv_data", owner: "www-data", group: "www-data", create: "true"
 
+    config.vm.synced_folders.each do |id, options|
+        # Make sure we use Samba for file mounts on Windows
+        if ! options[:type] && Vagrant::Util::Platform.windows?
+            options[:type] = "smb"
+        end
+    end
+
     if defined? VagrantPlugins::HostsUpdater
         config.hostsupdater.aliases = domains_array
     end


### PR DESCRIPTION
Since Ansible is struggling with permissions issues on VirtualBox-mounted
file shares, we should force file sharing to use Samba. Samba (SMB) is
similar to NFS and is more performant that VBox shares, but it also has
better permissions management and allows for provisioning to flow through
to execution.

Fixes #96

- [x] @markkelnar
- [x] @ericmann