### PR TITLE
Backup and restore databases

### DIFF
--- a/provisioning/roles/wordpress/handlers/main.yml
+++ b/provisioning/roles/wordpress/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: import WPE database
+  mysql_db:
+    name: wpe_{{ enviro }}
+    state: import
+    target: "{{ wp_doc_root }}/sqldumps/wpe_{{ enviro }}.sql"
+  when: mysql_import

--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -1,5 +1,20 @@
 - name: "Provision {{ enviro }} WP Databases"
-  mysql_db: name="wpe_{{ enviro }}" state=present
+  mysql_db:
+    name: "wpe_{{ enviro }}"
+    state: present
+  notify: import WPE database
+
+- name: "Ensure SQL dump directory exists"
+  file:
+    dest: "{{ wp_doc_root }}/sqldumps"
+    state: directory
+
+- name: "Back up {{ enviro }} WP database"
+  mysql_db:
+    name: wpe_{{ enviro }}
+    state: dump
+    target: "{{ wp_doc_root }}/sqldumps/wpe_{{ enviro }}.sql"
+  when: mysql_backup
 
 - name: "Grant {{ enviro }} WP users access to WP DBs"
   mysql_user: name="wpe_{{ enviro }}" priv="wpe_{{ enviro }}.*:ALL" host="%" password=wordpress state=present

--- a/provisioning/wordpress.yml
+++ b/provisioning/wordpress.yml
@@ -9,6 +9,8 @@
         role: wordpress,
         enviro: "{{ wp.enviro }}",
         domain: "{{ wp.hhvm_domains[0] }}",
+        mysql_import: "{{ wp.mysql_import | default(False) }}",
+        mysql_backup: "{{ wp.mysql_backup | default(False) }}",
         tags: [ 'wordpress' ]
       }
     - {


### PR DESCRIPTION
- [ ] @markkelnar
- [ ] @ericmann

I was noodling this one over last night and came up with a solution that's based on variables set in the custom site files, `mysql_backup` and `mysql_import`.  If you set these variables to `True` in your custom YAML file, it will 

* Create a backup of your site at `hgv_data/sites/sqldumps/[database name].sql` if you set `mysql_backup`
* Attempt a restore of your site from `hgv_data/sites/sqldumps/[database name].sql` if you set `mysql_import` *and* no database exists.

Putting this out there for discussion and to get it out of my head before I forget it.

Possible refinements:

* Move `sqldumps` a directory higher. I'm using `wp_doc_root` right now for convenience, but I'm thinking it belongs in `hgv_data/` proper
* Skip using custom variables to define this. This makes the handler a bit more unwieldy, but I could see checking for the existence of the SQL file instead of relying upon variables being set.
* I'm thinking at least the backup flag should be a requirement. VVV, for instance, used to do automatic backups for all installations. This *really* slows things down, so I'd like for this to be an explicitly-defined user-driven function.

The status quo is maintained with this PR -- existing deployment workflows are completely unaffected.