### PR TITLE
Remove documentation that is now found in the wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,28 +222,3 @@ PML is available at [admin.hgv.dev/logs](http://admin.hgv.dev/logs). You may use
 
 For detailed how to install guides per OS and other debugging information please see the [wiki here on github](https://github.com/wpengine/hgv/wiki).
 
-## HGV FAQ ##
-
-### I already use VVV, why do I need HGV? ###
-
-One of the great features of Vagrant is it allows developers to work locally on an environment that is as close as possible to their production environment.  While [VVV](https://github.com/varying-vagrant-vagrants/vvv) is an excellent WordPress development environment, it does not match any one hosting provider’s stack, it simply offers a common configuration.  HGV allows you to code locally on an environment that simulates the WP Engine Mercury platform, a highly tuned WordPress stack with forward looking technology not widely offered in the hosting ecosystem.  WP Engine has worked closely with Facebook to tune HHVM for the needs of WordPress, so you won’t get these constantly updating and improving configurations anywhere else.  
-
-### What is the license for HGV? ###
-
-HGV is Open Source and [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html).
-
-### How do I use my own domain? ###
-
-You can set that up manually, but currently there’s no automatic way to provision this and it is not supported in our documentation at this time.
-
-### How do I remove HGV from my system? ###
-
-From within the same directory you did “vagrant up” originally, type “vagrant destroy”.  The virtual machine will be destroyed (along with anything in it, so be sure to backup your databases!) and you can safely delete the directory if you don’t need to save any files within it.  HGV is continually improving, so feel free to reinstall and “destroy” as many times as you’d like!
-
-### Can I contribute back to HGV? ###
-
-Yes! HGV is open-sourced and hosted on GitHub. We encourage all users to submit bug reports and pull requests with features they would like to see. See the contributing file for how to start and rules.
-
-### What does “stdin: is not a tty” mean? ###
-
-Due to the way that Ubuntu configures its users, you may encounter this error the first time you run vagrant up or vagrant provision. It can safely be ignored and the provisioning process itself should remove the error on subsequent runs.

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -148,20 +148,6 @@ define('SAVEQUERIES', true);
 Enabling the Query Monitor WordPress plugin will allow logged-in users to view the useful debug information output by Xdebug, such as number of queries, number of objects, page render time, etc.
 
 ## FAQs ##
-### I already use VVV, why do I need HGV? ###
-One of the great features of Vagrant is it allows developers to work locally on an environment that is as close as possible to their production environment.  While VVV is an excellent WordPress development environment, it does not match any one hosting provider’s stack, it simply offers a common configuration.  HGV allows you to code locally on an environment that simulates the WPEngine Mercury platform, a highly tuned WordPress stack with forward looking technology not widely offered in the hosting ecosystem.  WPEngine has worked closely with Facebook to tune HHVM for the needs of WordPress, so you won’t get these constantly updating and improving configurations anywhere else.  
 
-### What is the license for HGV? ###
-HGV is Open Source and GPLv2.
-
-### How do I use my own domain? ###
-You can set that up manually, but currently there’s no automatic way to provision this and it is not supported in our documentation at this time.
-
-### How do I remove HGV from my system? ###
-From within the same directory you did “vagrant up” originally, type “vagrant destroy”.  The virtual machine will be destroyed (along with anything in it, so be sure to backup your databases!) and you can safely delete the directory if you don’t need to save any files within it.  HGV is continually improving, so feel free to reinstall and “destroy” as many times as you’d like!
-
-### Can I contribute back to HGV? ###
-Yes! HGV is open-sourced and hosted on GitHub. We encourage all users to submit bug reports and pull requests with features they would like to see.
-
-### What does “stdin: is not a tty” mean? ###
-Due to the way that Ubuntu configures its users, you may encounter this error the first time you run vagrant up or vagrant provision. It can safely be ignored and the provisioning process itself should remove the error on subsequent runs.
+### General FAQs ###
+Can be found on the [wiki](https://github.com/wpengine/hgv/wiki).


### PR DESCRIPTION
Remove duplicate text of general FAQs that I just moved to the wiki page (https://github.com/wpengine/hgv/wiki)

This is what the hgv.dev/ will look like at the bottom.
![screen shot 2015-06-15 at 4 46 31 pm](https://cloud.githubusercontent.com/assets/749603/8171566/647a53fa-137e-11e5-8893-e198a36a7a23.png)

- [x] @stephen-lin 
- [x] @markkelnar