### PR TITLE
Add initial details about how to setup more WP and custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The following WordPress tools and plugins are installed on each WP site (but are
 * [debug-bar](https://wordpress.org/plugins/debug-bar/)
 
 ### Accessing the sites on-disk ###
-HGV utilizes VirtualBox's [shared folders](https://www.virtualbox.org/manual/ch04.html#sharedfolders) to create a folder, `hgv_data`, that is accessible from both the HGV virtual machine and your operating system. This directory will be available for use after the first time the virtual machine is started using the `vagrant up` command. You can access the WP installations directly by going to `[HGV directory]/hgv_data/sites` in the Finder (Mac)/Explorer (Windows)/filesystem navigator of choice (Linux, Free/Open/NetBSD, etc.)
+HGV utilizes Vagrant's [synced folders](http://docs.vagrantup.com/v2/synced-folders/index.html) to create a folder, `hgv_data`, that is accessible from both the HGV virtual machine and your operating system. This directory will be available for use after the first time the virtual machine is started using the `vagrant up` command. You can access the WP installations directly by going to `[HGV directory]/hgv_data/sites` in the Finder (Mac)/Explorer (Windows)/filesystem navigator of choice (Linux, Free/Open/NetBSD, etc.)
 
 ### Installing plugins and themes ###
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ The following WordPress tools and plugins are installed on each WP site (but are
 * [debug-bar](https://wordpress.org/plugins/debug-bar/)
 
 ### Accessing the sites on-disk ###
-HGV utilizes VirtualBox's [shared folders](https://www.virtualbox.org/manual/ch04.html#sharedfolders) to create a folder, `hgv_data`, that is accessible from both the HGV virtual machine and your operating system. This directory will be available for use after the first time the virtual machine is started using the `vagrant up` command. You can access the WP installations directly by going to `[HGV directory]/hgv_data/sites/php` and `[HGV directory]/hgv_data/sites/hhvm` in the Finder (Mac)/Explorer (Windows)/filesystem navigator of choice (Linux, Free/Open/NetBSD, etc.)
+HGV utilizes VirtualBox's [shared folders](https://www.virtualbox.org/manual/ch04.html#sharedfolders) to create a folder, `hgv_data`, that is accessible from both the HGV virtual machine and your operating system. This directory will be available for use after the first time the virtual machine is started using the `vagrant up` command. You can access the WP installations directly by going to `[HGV directory]/hgv_data/sites` in the Finder (Mac)/Explorer (Windows)/filesystem navigator of choice (Linux, Free/Open/NetBSD, etc.)
 
 ### Installing plugins and themes ###
 
-Installing new plugins and themes is as simple as putting themes in `[HGV directory]/hgv_data/sites/[hhvm|php]/wp-content/[plugins|themes]`
+Installing new plugins and themes is as simple as putting themes in `[HGV directory]/hgv_data/sites/hhvm/wp-content/[plugins|themes]`
 
 ### Command line (CLI) access ###
 

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -1,6 +1,6 @@
 # Mercury Vagrant (HGV) #
 ### Getting Started ###
-This project is intended as a tool for allowing WP Engine users to test their code prior to actual deployment on WP Engine "Mercury" infrastructure. This is not intended as an *exact* replica of WP Engine's infrastructure, but is instead a "simulator" of the conditions and software stack on WPE's Mercury platform, allowing you to develop and test your code with an end goal of stability and compatibility with Mercury.
+This project is intended as a tool for allowing WP Engine users to test their code prior to actual deployment on WP Engine "Mercury" infrastructure. This is not intended as an *exact* replica of WP Engine's infrastructure, but is instead a "simulator" of the conditions and software stack on WP Engine's Mercury platform, allowing you to develop and test your code with an end goal of stability and compatibility with Mercury.
 
 Mercury differs from standard WordPress hosting in several ways, chief among which is the use of HHVM to serve all PHP code.
 
@@ -9,6 +9,18 @@ To quote HHVM's [website](http://hhvm.com/):
 > HHVM is an open-source virtual machine designed for executing programs written in Hack and PHP. HHVM uses a just-in-time (JIT) compilation approach to achieve superior performance while maintaining the development flexibility that PHP provides.
 
 ## What you get ##
+
+### Directory Layout ###
+The top level of the directory would contain files and directories like so:
+
+* Vagrantfile -- Vagrant provisioning file.
+* bin/ - A place for extra scripts used during provisioning of the Vagrant and WordPress'.
+* hgv_data/ -- User owned data. Gets shared/mounted with the Vagrant.
+ * sites/ -- Directory containing each WordPress.
+ * config/ -- User owned configuration files, example, custom-sites.yml files used for provisioning sites and domains.
+* provisioning/ -- The ansible provisioning code. Do not edit.
+ * default-install.yml -- The configuration for the default installed sites and domains. Do not edit.
+
 ### Software stack ###
 Once Vagrant is done provisioning the VM, you will have a box running [Ubuntu 14.04](http://releases.ubuntu.com/14.04/) (aka Trusty Tahr) containing
 
@@ -38,27 +50,63 @@ If you did *not* install the `vagrant-hostsupdater` plugin, you will need to man
 192.168.150.20 cache.php.hgv.dev
 ```
 
-### WordPress Installations ###
-There are two default WordPress installations provided. Both have an admin user `wordpress` with a password `wordpress` (so secure!) already created.
+## WordPress Installations ##
 
-#### php.hgv.dev ####
-[php.hgv.dev](http://php.hgv.dev) is a basic WordPress install running the latest stable version of WordPress on a fairly standard [LEMP stack](https://lemp.io/) consisting of Nginx, PHP-FPM, and Percona DB.
+### Default Installs ###
+There is one default WordPress installation provided and accessible at two domains. The provisioning details for this WordPress can be found in the file `provisioning/default-install.yml`.
 
 #### hhvm.hgv.dev ####
 [hhvm.hgv.dev](http://hhvm.hgv.dev) is a basic WordPress install running the latest stable version of WordPress on top of an Nginx + HHVM + Percona DB stack.
 
-#### WordPress developer tools ####
-The following WordPress tools and plugins are installed on each WP site (but are **not** enabled) by default:
+#### php.hgv.dev ####
+[php.hgv.dev](http://php.hgv.dev) is a basic WordPress install running the latest stable version of WordPress on a fairly standard [LEMP stack](https://lemp.io/) consisting of Nginx, PHP-FPM and Percona DB.
+
+### Database Access ###
+Both have an admin user `wordpress` with a password `wordpress` (so secure!) already created.
+
+### Accessing the sites on-disk (docroot) ###
+The default WordPress installations are accessible directly by going to `[HGV directory]/hgv_data/sites/hhvm` in the Finder (Mac)/Explorer (Windows)/filesystem navigator of choice (Linux, Free/Open/NetBSD, etc.).  When logged into the Vagrant ssh terminal, they are located at `/nas/wp/www/sites/hhvm`.
+
+### Developer Tools ###
+The following WordPress tools and plugins are installed on each WordPress site (but are **not** enabled) by default:
 
 * [query-monitor](https://wordpress.org/plugins/query-monitor/)
 * [debug-objects](https://wordpress.org/plugins/debug-objects/)
 * [debug-bar](https://wordpress.org/plugins/debug-bar/)
 
-#### Accessing the sites on-disk ####
-When you Users can access the WP installations directly by going to `[HGV directory]/hgv_data/sites/hhvm` and `[HGV directory]/hgv_data/sites/php` in the Finder (Mac)/Explorer (Windows)/filesystem navigator of choice (Linux, Free/Open/NetBSD, etc.)
+### Installing plugins and themes ###
+Installing new plugins and themes is as simple as putting themes in `[HGV directory]/hgv_data/sites/hhvm/wp-content/[plugins|themes]`
 
-#### Installing plugins and themes ####
-Installing new plugins and themes is as simple as putting themes in `[HGV directory]/hgv_data/sites/[hhvm|php]/wp-content/[plugins|themes]`
+
+## Add My Own WordPress ##
+
+### The Provision File ###
+Let HGV provision your WordPress for you.
+
+1. Copy provisioning/default-install.yml to hgv_data/config/foo.yml.
+2. Change the `enviro` variable to the docroot of where your WordPress lives under `[HGV directory]/hgv_data/sites/`, ie 'foo'. If the directory does not exist when provisioning is executed, it will be created and the latest stable version or WordPress installed.
+3. Edit the domain lists to be the domain(s) you want setup for the WordPress residing in the Vagrant. Domains listed under `hhvm_domains` will be served by HHVM.  Those listed under `php_domains` will be served by the PHP-FPM service.
+
+If you did not install the vagrant-hostsupdater plugin, you will need to manually add the domains to your host operating system’s host files. See the example [above](/#mercury-vagrant-hgv-what-you-get-sites).
+
+### Example ###
+
+hgv_data/config/foo.yml
+
+```
+---
+wp:
+  enviro: foo
+  hhvm_domains:
+    - foo.local
+    - www.foo.local
+  php_domains:
+    - php.foo.local
+```
+
+### Provision ###
+After editing or adding a new configuration, for the changes to take effect, you must run `vagrant provision` on an already provisioned environment.
+
 
 ## Admin Tools ##
 HGV contains several useful tools for gathering system state and for administering individual aspects of the system.


### PR DESCRIPTION
Documentation of custom domains and additional WP to be provisioned to run in HGV.
Most of this documentation resides in the hgv.dev/ dashboard.  I changed a small amount in the top level readme.  There is more we could remove from that readme to slim it down.

https://github.com/wpengine/hgv/issues/165
https://github.com/wpengine/hgv/issues/169
https://github.com/wpengine/hgv/issues/170 


- [x] @stephen-lin 
- [x] @ericmann