### PR TITLE
Top level domain to .test

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ vagrant_name = File.basename(dir)
 
 require 'yaml'
 
-domains_array = ['admin.hgv.dev', 'xhprof.hgv.dev', 'mail.hgv.dev', 'admin.hgv.test', 'xhprof.hgv.test', 'mail.hgv.test']
+domains_array = ['hgv.dev', 'admin.hgv.dev', 'xhprof.hgv.dev', 'mail.hgv.dev', 'admin.hgv.test', 'xhprof.hgv.test', 'mail.hgv.test']
 
 def domains_from_yml(file)
     ret = []

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ vagrant_name = File.basename(dir)
 
 require 'yaml'
 
-domains_array = ['admin.hgv.dev', 'xhprof.hgv.dev', 'mail.hgv.dev']
+domains_array = ['admin.hgv.dev', 'xhprof.hgv.dev', 'mail.hgv.dev', 'admin.hgv.test', 'xhprof.hgv.test', 'mail.hgv.test']
 
 def domains_from_yml(file)
     ret = []
@@ -38,7 +38,7 @@ end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "ubuntu/trusty64"
-    config.vm.hostname = "hgv.dev"
+    config.vm.hostname = "hgv.test"
     config.vm.network "private_network", ip: "192.168.150.20"
     config.vm.network "forwarded_port", guest: 3306, host: 23306
     config.vm.network "forwarded_port", guest: 9001, host: 29001

--- a/provisioning/default-install.yml
+++ b/provisioning/default-install.yml
@@ -2,5 +2,9 @@
 ---
 wp:
   enviro: hhvm
-  hhvm_domains: [ 'hhvm.hgv.dev' ]
-  php_domains: [ 'php.hgv.dev', 'fpm.hgv.dev' ]
+  hhvm_domains:
+    - hhvm.hgv.dev
+    - hhvm.hgv.test
+  php_domains:
+    - php.hgv.dev
+    - php.hgv.test

--- a/provisioning/roles/admin/files/etc/nginx/conf.d/mail.conf
+++ b/provisioning/roles/admin/files/etc/nginx/conf.d/mail.conf
@@ -1,6 +1,6 @@
 server {
         listen          80;
-        server_name     mail.hgv.dev;
+        server_name     mail.hgv.dev mail.hgv.test;
 
         access_log  /var/log/nginx/mail.hgv.dev.access.log  wpengine;
         access_log  /var/log/nginx/mail.hgv.dev.apachestyle.access.log  apachestandard;

--- a/provisioning/roles/admin/templates/etc/nginx/conf.d/admin.conf
+++ b/provisioning/roles/admin/templates/etc/nginx/conf.d/admin.conf
@@ -1,6 +1,6 @@
 server {
        listen   {{ nginx_listen_port }};
-       server_name admin.hgv.dev;
+       server_name admin.hgv.dev admin.hgv.test;
        root /nas/wp/www/sites/admin;
 
        index index.php index.html;

--- a/provisioning/roles/nginx/templates/etc/nginx/conf.d/dashboard.conf
+++ b/provisioning/roles/nginx/templates/etc/nginx/conf.d/dashboard.conf
@@ -1,6 +1,6 @@
 server {
         listen   {{ nginx_listen_port }} default;
-        server_name  _ hgv.dev;
+        server_name  _ hgv.dev hgv.test;
         root {{ wp_doc_root }}/dashboard;
 
         location / {

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -98,10 +98,10 @@ hgv_data/config/foo.yml
 wp:
   enviro: foo
   hhvm_domains:
-    - foo.local
-    - www.foo.local
+    - foo.test
+    - www.foo.test
   php_domains:
-    - php.foo.local
+    - php.foo.test
 ```
 
 ### Provision ###

--- a/provisioning/roles/xhprof/templates/etc/nginx/conf.d/xhprof.conf
+++ b/provisioning/roles/xhprof/templates/etc/nginx/conf.d/xhprof.conf
@@ -1,6 +1,6 @@
 server {
     listen   80;
-    server_name  xhprof.hgv.dev;
+    server_name  xhprof.hgv.dev xhprof.hgv.test;
     root /opt/xhprof/xhprof_html;
     access_log  /var/log/nginx/xhprof.hgv.dev.access.log  wpengine;
     access_log  /var/log/nginx/xhprof.hgv.dev.apachestyle.access.log  apachestandard;


### PR DESCRIPTION
Add in hgv.test to the existing hgv.dev domains and tools we setup for HGV.

Does not disable, remove or stop functionality of existing *.hgv.dev domains at this point.  We will deprecate and remove those at later code changes and releases.

https://github.com/wpengine/hgv/issues/98

- [x] @markkelnar 
- [x] @ericmann