### PR TITLE
Increase max upload size

### DIFF
--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -13,3 +13,5 @@ web_user: www-data
 web_group: www-data
 
 xhprof_root: /opt/xhprof
+
+file_upload_max_size: 200

--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -14,4 +14,5 @@ web_group: www-data
 
 xhprof_root: /opt/xhprof
 
+## Arbitrary max upload size. Fixes upload limit problems.
 file_upload_max_size: 200

--- a/provisioning/roles/nginx/templates/etc/nginx/nginx.conf
+++ b/provisioning/roles/nginx/templates/etc/nginx/nginx.conf
@@ -13,7 +13,6 @@ http {
 	# Basic Settings
 	##
 
-	## Arbitrary max upload size
 	client_max_body_size {{ file_upload_max_size }}m;
 
 	sendfile off;

--- a/provisioning/roles/nginx/templates/etc/nginx/nginx.conf
+++ b/provisioning/roles/nginx/templates/etc/nginx/nginx.conf
@@ -13,6 +13,9 @@ http {
 	# Basic Settings
 	##
 
+	## Arbitrary max upload size
+	client_max_body_size {{ file_upload_max_size }}m;
+
 	sendfile off;
 	tcp_nopush on;
 	tcp_nodelay on;

--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -64,3 +64,14 @@
 # - name: Do fpm/php.ini
 #   template: src=etc/php5/fpm/php.ini dest=/etc/php5/fpm/php.ini owner=root group=root mode=0644
 #   notify: php5-fpm restart
+
+- name: Set the max file upload size
+  ini_file:
+    dest: /etc/php5/fpm/php.ini
+    section: "PHP"
+    option: "{{ item }}"
+    value: "{{ file_upload_max_size }}M"
+  with_items:
+    - upload_max_filesize
+    - post_max_size
+


### PR DESCRIPTION
Fix for https://github.com/wpengine/hgv/issues/178

- [x] @markkelnar
- [ ] @ericmann
- [x] @stephen-lin

Steps to recreate, upload a SQL file larger than 8Mb to admin.hgv.test/phpmyadmin.