### PR TITLE
Contributing details and the develop branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,9 @@ The **master** branch is the latest stable release.  The **develop** branch is w
 
 Submit a pull request at any time, whether an issue has been created or not. It may be helpful to discuss your goals in an issue first, though many things can best be shown with code.
 
-We do ask that the pull request be submitted against the **develop** branch from a feature branch in your fork of the project in GitHub. Every effort is made to make the pull request as stable as possible before merging it in, so we aren't too worried.
+We do ask that the pull request be submitted against the **develop** branch from a feature branch in your fork of the project in GitHub. We ask that you test your code as we will also do our best to code review, test and verify that the pull request is as stable as possible before merging it.
+
+We also encourage you to pull down code you see in someone else's pull request, test it and provide your findings in a comment, that's always fun and helpful to the community project.
 
 Please add the following markdown task lists (checkboxes) to each pull request description.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,17 @@ Open a GitHub issue for anything. Don't worry if you find yourself opening somet
 
 Comment on any GitHub issue, open or closed. The only guidelines here are to be friendly and welcoming. If you see that a question has been asked and you think you know the answer, feel free to respond. No need to wait!
 
-## Pull Requests
+## Code Submission ##
+
+### Work Flow ###
+
+The **master** branch is the latest stable release.  The **develop** branch is where new features and on-going development take place.  The next stable release will come from the **develop** branch.
+
+### Pull Requests ###
 
 Submit a pull request at any time, whether an issue has been created or not. It may be helpful to discuss your goals in an issue first, though many things can best be shown with code.
 
-We do ask that the pull request be submitted against the current **master** branch. Every effort is made to make the pull request as stable as possible before merging it in, so we aren't too worried. A list of stable releases is maintained as we go and can be used by anyone concerned by ongoing development.
+We do ask that the pull request be submitted against the **develop** branch from a feature branch in your fork of the project in GitHub. Every effort is made to make the pull request as stable as possible before merging it in, so we aren't too worried.
 
 Please add the following markdown task lists (checkboxes) to each pull request description.
 
@@ -28,6 +34,14 @@ Please add the following markdown task lists (checkboxes) to each pull request d
 ```
 
 After reviewing the PR, the reviewer will check their box.  When box boxes are checked, the PR is considered approved and able to be merged.
+
+### Hotfixes ###
+
+If a bug fix or code change is deemed important enough that it should be fixed in the latest stable release, the pull request should be targeted at the **master** branch. with the same markdown checkboxes provided above.
+
+Once reviewed and tested, it will be merged and a new 'patch' release will be created following the instructions below.
+
+After a release is created, any changes introduced into **master** that bypassed the **develop** branch, should be merged into the **develop** branch.  This can be done in GitHub as a pull request.
 
 ## Code Style ##
 


### PR DESCRIPTION
We are changing to introduce a 'develop' branch which will be the target of on-going code improvements without changing the latest stable release which will be found and tagged in the 'master' branch.  

@zamoose you might be interested in this workflow change.

New PR requests that come in will be expected to be targeted at develop.  We will work with existing PR's that are targeted at master to figure out if those need to be retargeted at develop.

PS. This PR is targeted at master because we are in this transition and want to get the documentation out.

https://github.com/wpengine/hgv/issues/29

- [x] @markkelnar
- [x] @ericmann
- [x] @stephen-lin