### PR TITLE
Enable and specify file upload size in hhvm

### DIFF
--- a/provisioning/roles/hhvm/templates/etc/hhvm/server.ini
+++ b/provisioning/roles/hhvm/templates/etc/hhvm/server.ini
@@ -4,6 +4,12 @@ pid = /var/run/hhvm/pid
 
 ; hhvm specific
 
+upload_max_filesize = {{ file_upload_max_size }}M
+post_max_size = {{ file_upload_max_size }}M
+
+; Fix for https://github.com/facebook/hhvm/issues/4993 until there's a more permanent fix
+hhvm.enable_zend_ini_compat = false
+
 hhvm.server.file_socket = /var/run/hhvm/hhvm.sock
 hhvm.server.type = fastcgi
 hhvm.server.default_document = index.php


### PR DESCRIPTION
High level summary

The file upload limit is broken right now in HHVM because there is a bug where it can't correctly parse the environment's allowed file upload size. So when the user is trying to upload files in the WP admin, the upload file size is empty and it doesn't respect the options and limits in the ini file.

Approach

Enable the hhvm server.ini option as provided by the HHVM team.

- [x] @markkelnar
- [ ] @ericmann
- [x] @stephen-lin