### PR TITLE
Allow for custom plugins

### DIFF
--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -16,3 +16,10 @@ xhprof_root: /opt/xhprof
 
 ## Arbitrary max upload size. Fixes upload limit problems.
 file_upload_max_size: 200
+
+default_plugins:
+  - query-monitor
+  - debug-objects
+  - debug-queries
+  - debug-bar
+  - wordpress-importer

--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -81,12 +81,9 @@
   command: /usr/local/bin/wp plugin install {{ item }}
   sudo: yes
   sudo_user: "{{ web_user }}"
-  with_items:
-      - query-monitor
-      - debug-objects
-      - debug-queries
-      - debug-bar
-      - wordpress-importer
+  with_flattened:
+    - "{{ wp.custom_plugins|default([]) }}"
+    - default_plugins
   args:
       chdir: "{{ wp_doc_root }}/{{ enviro }}"
       creates: "{{ wp_doc_root }}/{{ enviro }}/wp-content/plugins/{{ item }}"


### PR DESCRIPTION
* [x] @markkelnar 
* [ ] @ericmann 
* [x] @stephen-lin 

Addressing #188:
This change will allow users to add a list, `custom_plugins` to their site-custom YAML files and have additional plugins added to the roster installed when provisioning a site. 

For instance, I have a custom .yml file that has this:

```yaml
---
wp:
  enviro: laravel
  hhvm_domains:
    - hhvm.laravel.hgv.dev
  php_domains:
    - laravel.hgv.dev
  custom_plugins:
    - wordpress-seo
    - revisr
```

When run, the default plugins are installed as well as `wordpress-seo` and `revisr`.