### PR TITLE
Add Amazon S3 plugin to the list

### DIFF
--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -23,4 +23,7 @@ default_plugins:
   - debug-queries
   - debug-bar
   - wordpress-importer
-  - "https://github.com/humanmade/S3-Uploads/archive/master.zip"
+
+default_repo_plugins:
+  - slug: S3-Uploads-master
+    url: "https://github.com/humanmade/S3-Uploads/archive/master.zip"

--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -23,3 +23,4 @@ default_plugins:
   - debug-queries
   - debug-bar
   - wordpress-importer
+  - "https://github.com/humanmade/S3-Uploads/archive/master.zip"

--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -87,3 +87,12 @@
   args:
       chdir: "{{ wp_doc_root }}/{{ enviro }}"
       creates: "{{ wp_doc_root }}/{{ enviro }}/wp-content/plugins/{{ item }}"
+
+- name: "Install useful plugins from VCS repos for {{ enviro }}"
+  command: /usr/local/bin/wp plugin install {{ item.url }}
+  sudo: yes
+  sudo_user: "{{ web_user }}"
+  with_items: "{{ default_repo_plugins }}"
+  args:
+    chdir: "{{ wp_doc_root }}/{{ enviro }}"
+    creates: "{{ wp_doc_root }}/{{ enviro }}/wp-content/plugins/{{ item.slug }}"


### PR DESCRIPTION
- [ ] @markkelnar
- [ ] @ericmann

Add the [S3 Uploads](https://github.com/humanmade/S3-Uploads) plugin to the default plugins list. Fixes #114.

This does admitedly break [this check](https://github.com/wpengine/hgv/blob/master/provisioning/roles/wordpress/tasks/main.yml#L92) in ansible, but I'm not sure if there is a good way around that when downloading a plugin from a zip file instead of installing from the repo.