### PR TITLE
Add support for xip.io service

### DIFF
--- a/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
+++ b/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
@@ -1,6 +1,6 @@
 server {
 	listen          80;
-	server_name     {% for i in domain %}{{ i }} {% endfor %};
+	server_name     {% for i in domain %}{{ i }} {% for ip in ansible_all_ipv4_addresses %}{{ i|replace(".dev",".%s.xip.io"|format(ip)) }} {% endfor %}{% endfor %};
 	root            {{ wp_doc_root }}/{{ enviro }};
 
 	index index.php;

--- a/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
+++ b/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
@@ -1,6 +1,6 @@
 server {
 	listen          80;
-	server_name     {% for i in domain %}{{ i }} {% for ip in ansible_all_ipv4_addresses %}{{ i|replace(".dev",".%s.xip.io"|format(ip)) }} {% endfor %}{% endfor %};
+	server_name     {% for i in domain %}{{ i }} {{ "~^%s\d+\.\d+\.\d+\.\d+\.xip\.io$"|format(i|replace(".dev",".")|replace(".","\.")) }} {% endfor %};
 	root            {{ wp_doc_root }}/{{ enviro }};
 
 	index index.php;

--- a/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
+++ b/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
@@ -1,6 +1,6 @@
 server {
 	listen          80;
-	server_name     {% for i in domain %}{{ i }} {{ "~^%s\d+\.\d+\.\d+\.\d+\.xip\.io$"|format(i|replace(".","\.")) }} {% endfor %};
+	server_name     {% for i in domain %}{{ i }} {{ "~^%s\.\d+\.\d+\.\d+\.\d+\.xip\.io$"|format(i|replace(".","\.")) }} {% endfor %};
 	root            {{ wp_doc_root }}/{{ enviro }};
 
 	index index.php;

--- a/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
+++ b/provisioning/roles/listener/templates/etc/nginx/wordpress.conf
@@ -1,6 +1,6 @@
 server {
 	listen          80;
-	server_name     {% for i in domain %}{{ i }} {{ "~^%s\d+\.\d+\.\d+\.\d+\.xip\.io$"|format(i|replace(".dev",".")|replace(".","\.")) }} {% endfor %};
+	server_name     {% for i in domain %}{{ i }} {{ "~^%s\d+\.\d+\.\d+\.\d+\.xip\.io$"|format(i|replace(".","\.")) }} {% endfor %};
 	root            {{ wp_doc_root }}/{{ enviro }};
 
 	index index.php;


### PR DESCRIPTION
- [ ] @markkelnar
- [ ] @ericmann

VVV [recently](https://github.com/Varying-Vagrant-Vagrants/VVV/pull/449) added support for the [Xip.io](http://xip.io) service. This is extremely useful when attempting to access local development sites from other devices on the same network.

To test this change, do the following:

* Check out the `xipio` branch from [my repo](http://github.com/JPry/hgv).
* Create a file located in `~/.vagrant.d/Vagrantfile` with the following content:
```
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure(2) do |config|
  # Set up with a Public network
  config.vm.network :public_network
end
```
* Run `vagrant reload --provision`
* SSH to the vagrant, and determine the public IP address using `ifconfig`. My experience indicates that the `eth1` interface normally has the public IP, but your results may vary.
* Connect to one of the default sites, adding `.<ip address>.xip.io` to the end of the domain name. In my testing, my IP was `192.168.1.22`, so the domain ended up being `php.hgv.dev.192.168.1.22.xip.io`.

If all goes well, you should see a WordPress site and be able to login and click around normally.