### PR TITLE
Make sure bundled keys aren't CRLF'ed upon checkout.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
+
+# Explicitly declare files that will always have LF line endings on checkout
+*.key text eol=lf


### PR DESCRIPTION
- [x] @markkelnar
- [x] @ericmann

By default, we're attempting to force Git to respect the line endings of specific files, but Varnish's GPG key is still a sticking point on some checkouts. This change will force any file ending in `*.key` to _always_ be checked out with LF style ending, even on Windows, so when mounted into the VM we won't run into errors like those reported in #193 and other tickets.

Fixes #195 