### PR TITLE
Enable Customfile Overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 wpengine_data/
 hgv_data/
 .DS_Store
+Customfile

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,6 +82,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # This allows the git commands to work using host server keys
     config.ssh.forward_agent = true
 
+    # Use a Customfile in the same directory as this Vagrantfile to evaluate (and possibly
+    # rewrite) Vagrant configuration lines. Everything in the Customfile will be avaluated
+    # as inline Ruby commands, so this is quite possible.
+    if File.exists?(File.join(vagrant_dir,'Customfile')) then
+      eval(IO.read(File.join(vagrant_dir,'Customfile')), binding)
+    end
+
     # To avoid stdin/tty issues
     config.vm.provision "fix-no-tty", type: "shell" do |s|
         s.privileged = false


### PR DESCRIPTION
- [x] @markkelnar
- [x] @ericmann

Utilize the same `Customfile` setup that powers runtime configuration
changes in [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV). Placing
a `Customfile` in the root of the HGV installation will allow developers
to override specific configuration options, add extra providers, inject
additional provisioning steps, etc.

Fixes #197.