### PR TITLE
Don't Overwrite Constant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_API_VERSION = "2" unless defined? VAGRANTFILE_API_VERSION
 
 dir = Dir.pwd
 vagrant_dir = File.expand_path(File.dirname(__FILE__))


### PR DESCRIPTION
- [x] @markkelnar
- [x] @ericmann

If multiple HGV installations exist on the host, commands like `vagrant
global-status` attempt to parse all of the Vagrantfiles. This can cause
problems since all of them declare `VAGRANTFILE_API_VERSION`. By problems,
I mean this will trigger a Ruby warning that mucks with proper output.

To better protect against conflicts, we should check to see if the
constant is defined before we set it so we can avoid stumbling over
multiple installations co-located on a machine.