### PR TITLE
Add multisite config

### DIFF
--- a/provisioning/roles/nginx/tasks/main.yml
+++ b/provisioning/roles/nginx/tasks/main.yml
@@ -26,6 +26,14 @@
   template: src=etc/nginx/conf.d/upstream.conf dest=/etc/nginx/conf.d/upstream.conf owner=root group=root mode=0644
   notify: nginx restart
 
+- name: Push out Wordpress include file
+  template: src=etc/nginx/conf.d/wordpress-site dest=/etc/nginx/conf.d/wordpress-site owner=root group=root mode=0644
+  notify: nginx restart
+
+- name: Push out Wordpress Multisite include file
+  template: src=etc/nginx/conf.d/wordpress-multisite dest=/etc/nginx/conf.d/wordpress-multisite owner=root group=root mode=0644
+  notify: nginx restart
+
 - name: Remove default.conf
   file: path=/etc/nginx/conf.d/default.conf state=absent
 

--- a/provisioning/roles/nginx/templates/etc/nginx/conf.d/wordpress-multisite
+++ b/provisioning/roles/nginx/templates/etc/nginx/conf.d/wordpress-multisite
@@ -1,0 +1,10 @@
+# WordPress multisite subdirectory rules.
+# Designed to be included in any server {} block.
+# Use when in fast-cgi mode and not using .htaccess file.
+
+# Rewrite multisite '.../wp-.*' and '.../*.php'.
+if (!-e $request_filename) {
+        rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+        rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
+        rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;
+}

--- a/provisioning/roles/nginx/templates/etc/nginx/conf.d/wordpress-site
+++ b/provisioning/roles/nginx/templates/etc/nginx/conf.d/wordpress-site
@@ -1,0 +1,8 @@
+# WordPress single blog rules.
+# Designed to be included in any server {} block.
+# Use when in fast-cgi mode and not using .htaccess file.
+
+# http://wiki.nginx.org/HttpCoreModule
+location / {
+        try_files $uri $uri/ /index.php?$args;
+}

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -107,6 +107,15 @@ wp:
 ### Provision ###
 After editing or adding a new configuration, for the changes to take effect, you must run `vagrant provision` on an already provisioned environment.
 
+### Multisite ###
+
+If your WordPress is a multisite, it requires certain configurations in the environment to know this is what you want.  So, in your YAML config file, add the *multisite* option and re-provision the vagrant.
+
+```
+wp:
+  ...
+  multisite: yes
+```
 
 ## Admin Tools ##
 HGV contains several useful tools for gathering system state and for administering individual aspects of the system.

--- a/provisioning/roles/wordpress/templates/etc/nginx/conf.d/wordpress.conf
+++ b/provisioning/roles/wordpress/templates/etc/nginx/conf.d/wordpress.conf
@@ -20,7 +20,7 @@ server {
 	# WordPress blog rules.
 	include /etc/nginx/conf.d/wordpress-site;
 
-{% if wp.multisite %}
+{% if wp.multisite | default(False) %}
 	# WordPress multisite rules.
 	include /etc/nginx/conf.d/wordpress-multisite;
 {% endif %}

--- a/provisioning/roles/wordpress/templates/etc/nginx/conf.d/wordpress.conf
+++ b/provisioning/roles/wordpress/templates/etc/nginx/conf.d/wordpress.conf
@@ -17,14 +17,13 @@ server {
 	access_log  /var/log/nginx/{{ enviro }}.apachestyle.access.log  apachestandard;
 	error_log  /var/log/nginx/{{ enviro }}.error.log warn;
 
-	# WordPress single blog rules.
-	# Designed to be included in any server {} block.
+	# WordPress blog rules.
+	include /etc/nginx/conf.d/wordpress-site;
 
-	# This order might seem weird - this is attempted to match last if rules below fail.
-	# http://wiki.nginx.org/HttpCoreModule
-	location / {
-		try_files $uri $uri/ /index.php?$args;
-	}
+{% if wp.multisite %}
+	# WordPress multisite rules.
+	include /etc/nginx/conf.d/wordpress-multisite;
+{% endif %}
 
 	# Add trailing slash to */wp-admin requests.
 	rewrite /wp-admin$ $scheme://$host$uri/ permanent;

--- a/test/codeception/.gitignore
+++ b/test/codeception/.gitignore
@@ -3,3 +3,4 @@
 /functional/FunctionalTester.php
 /acceptance/AcceptanceTester.php
 _generated/
+_output/

--- a/test/codeception/tests/acceptance/DefaultWPCest.php
+++ b/test/codeception/tests/acceptance/DefaultWPCest.php
@@ -1,0 +1,31 @@
+<?php
+use \AcceptanceTester;
+
+class DefaultWPCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+    }
+
+    public function _after(AcceptanceTester $I)
+    {
+    }
+
+    // tests
+    public function viewPageHHVM(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://hhvm.hgv.test');
+        $I->amOnPage('/');
+        $I->seeCurrentUrlEquals('/');
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewPagePHP(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://php.hgv.test');
+        $I->amOnPage('/');
+        $I->seeCurrentUrlEquals('/');
+        $I->seeResponseCodeIs(200);
+    }
+
+}

--- a/test/codeception/tests/acceptance/MultisiteDirectoryCest.php
+++ b/test/codeception/tests/acceptance/MultisiteDirectoryCest.php
@@ -1,0 +1,45 @@
+<?php
+use \AcceptanceTester;
+
+class MultisiteDirectoryCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+    }
+
+    public function _after(AcceptanceTester $I)
+    {
+    }
+
+    // tests
+    public function viewPageHHVM(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://multidirectory.test');
+        $I->amOnPage('/foo/');
+        $I->seeCurrentUrlEquals('/foo/');
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewPagePHP(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://phpmultidirectory.test');
+        $I->amOnPage('/foo/');
+        $I->seeCurrentUrlEquals('/foo/');
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewPageHHVM404(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://multidirectory.test');
+        $I->amOnPage('/bar');
+        $I->seeResponseCodeIs(404);
+    }
+
+    public function viewPagePHP404(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://phpmultidirectory.test');
+        $I->amOnPage('/bar');
+        $I->seeResponseCodeIs(404);
+    }
+
+}

--- a/test/codeception/tests/acceptance/MultisiteDomainCest.php
+++ b/test/codeception/tests/acceptance/MultisiteDomainCest.php
@@ -1,0 +1,38 @@
+<?php
+use \AcceptanceTester;
+
+class MultisiteDomainCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+    }
+
+    public function _after(AcceptanceTester $I)
+    {
+    }
+
+    // tests
+    public function viewPageHHVM(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://multidomain.test');
+        $I->amOnPage('/');
+        $I->seeCurrentUrlEquals('/');
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewPagePHP(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://php.multidomain.test');
+        $I->amOnPage('/');
+        $I->seeCurrentUrlEquals('/');
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewPageHHVM404(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://multidomain.test');
+        $I->amOnPage('/not-exist');
+        $I->seeResponseCodeIs(404);
+    }
+
+}


### PR DESCRIPTION
The Nginx config does not support WordPress multisite subdirectory.

This is an attempt to add the Nginx rules to handle the rewrite.  Extracted from https://codex.wordpress.org/Nginx#WordPress_Multisite_Subdirectory_rules

Also adds an option to the WP config/yml file if the WordPress is a multisite.  Is this a practical way to identify that the WP is a multisite or is expected to be a multisite?

Example:
```
wp
   hhvm_domains:
      - foo.test
   multisite: yes
```

What's missing?
test.yml ansible tasks that install the WPs that satisfy the tests.