### PR TITLE
Extract varnish vcl template to a variable

### DIFF
--- a/bin/custom-sites.sh
+++ b/bin/custom-sites.sh
@@ -20,11 +20,16 @@ fi
 export PYTHONUNBUFFERED=1
 export ANSIBLE_FORCE_COLOR=true
 
+# If user specified ansible extra variables file is provided, pass that in to the provisioning
+if [ -e "/vagrant/hgv_data/config/provisioning/ansible.yml" ] ; then
+    EXTRA="@/vagrant/hgv_data/config/provisioning/ansible.yml"
+fi
+
 shopt -s nullglob
 for file in /vagrant/provisioning/default-install.yml /vagrant/hgv_data/config/*.yml
 do
     echo "### Provisioning $file ###"
-    $ANS_BIN /vagrant/provisioning/wordpress.yml -i'127.0.0.1,' --extra-vars="@$file"
+    $ANS_BIN /vagrant/provisioning/wordpress.yml -i'127.0.0.1,' --extra-vars="@$file" --extra-vars="$EXTRA"
 done
 
 echo

--- a/bin/hgv-init.sh
+++ b/bin/hgv-init.sh
@@ -60,4 +60,8 @@ chmod 644 /vagrant/provisioning/hosts
 export PYTHONUNBUFFERED=1
 export ANSIBLE_FORCE_COLOR=true
 
-$ANS_BIN /vagrant/provisioning/playbook.yml -i'127.0.0.1,'
+# If user specified ansible extra variables file is provided, pass that in to the provisioning
+if [ -e "/vagrant/hgv_data/config/provisioning/ansible.yml" ] ; then
+    EXTRA="@/vagrant/hgv_data/config/provisioning/ansible.yml"
+fi
+$ANS_BIN /vagrant/provisioning/playbook.yml -i'127.0.0.1,' --extra-vars="$EXTRA" -vvvv

--- a/bin/hgv-init.sh
+++ b/bin/hgv-init.sh
@@ -64,4 +64,4 @@ export ANSIBLE_FORCE_COLOR=true
 if [ -e "/vagrant/hgv_data/config/provisioning/ansible.yml" ] ; then
     EXTRA="@/vagrant/hgv_data/config/provisioning/ansible.yml"
 fi
-$ANS_BIN /vagrant/provisioning/playbook.yml -i'127.0.0.1,' --extra-vars="$EXTRA" -vvvv
+$ANS_BIN /vagrant/provisioning/playbook.yml -i'127.0.0.1,' --extra-vars="$EXTRA"

--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -12,6 +12,10 @@ vagrant_doc_root: /hgv_data/sites
 web_user: www-data
 web_group: www-data
 
+usr_config: /hgv_data/config
+usr_config_sites: /hgv_data/config/sites
+usr_config_provision: /hgv_data/config/provisioning
+
 xhprof_root: /opt/xhprof
 
 ## Arbitrary max upload size. Fixes upload limit problems.

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -43,5 +43,14 @@
     dest: /usr/local/bin/codecept
     mode: 0755
 
+- name: Create custom config directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ usr_config }}"
+    - "{{ usr_config_sites }}"
+    - "{{ usr_config_provision }}"
+
 - include: swap.yml
 - include: daemonize.yml

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -213,6 +213,23 @@ When you want to disable profiling, simply append `_profile=0` to any request, o
 Visiting those links should delete the cookie and disable XHProf.
 
 
+## Overriding environment defaults ##
+
+### Maintain your own overrides file ###
+
+1) Add YAML formatted file in hgv_data/config/provisioning/ansible.yml containing the ansible variable(s) you wish to override.
+
+2) After editing or adding a new configuration, for the changes to take effect, you must run `vagrant provision`.
+
+### Example ###
+
+This is an example of changing the max file upload size allowed by Nginx, HHVM, PHP-FPM and the WordPress.
+
+```
+---
+file_upload_max_size: 50
+```
+
 ## FAQs ##
 
 ### General FAQs ###

--- a/provisioning/roles/varnish/defaults/main.yml
+++ b/provisioning/roles/varnish/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+varnish_default_vcl_template: etc/varnish/default.vcl

--- a/provisioning/roles/varnish/defaults/main.yml
+++ b/provisioning/roles/varnish/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-
 varnish_default_vcl_template: etc/varnish/default.vcl

--- a/provisioning/roles/varnish/tasks/main.yml
+++ b/provisioning/roles/varnish/tasks/main.yml
@@ -15,7 +15,7 @@
   notify: varnish reload
 
 - name: Ensure varnish default.vcl
-  template: src=etc/varnish/default.vcl dest=/etc/varnish/default.vcl owner=root group=root mode=0644
+  template: src={{ varnish_default_vcl_template }} dest=/etc/varnish/default.vcl owner=root group=root mode=0644
   notify: varnish reload
 
 - name: Enable NCSA-style logging

--- a/test/codeception/tests/acceptance/VarnishCest.php
+++ b/test/codeception/tests/acceptance/VarnishCest.php
@@ -1,0 +1,20 @@
+<?php
+use \AcceptanceTester;
+
+class VarnishCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+    }
+
+    public function _after(AcceptanceTester $I)
+    {
+    }
+
+    // tests
+    public function configExists(AcceptanceTester $I)
+    {
+        $I->wantTo('Check for existance of config file');
+        $I->seeFileFound('default.vcl', '/etc/varnish/');
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/wpengine/hgv/issues/209

Extract varnish VCL template file path to a variable.  Add support for the playbook to import ansible.yml which could contain overrides to the default variables.  Thus allowing users to expand the environment to their own preference.