### PR TITLE
Map domains to host variable not http_host

### DIFF
--- a/provisioning/roles/wordpress/templates/etc/nginx/conf.d/wordpress.conf
+++ b/provisioning/roles/wordpress/templates/etc/nginx/conf.d/wordpress.conf
@@ -1,5 +1,5 @@
 # During vagrant provisioning, this map of domains to the backend PHP processor is populated
-map $http_host $upstream_target_{{ enviro }} {
+map $host $upstream_target_{{ enviro }} {
     hostnames;
 
     ## Upstream for {{ enviro }} ## After this line, domains are inserted by the provisioning scripts. Do Not Edit.


### PR DESCRIPTION
I was playing around with setting the Nginx listen port to 8080 (something other than port 80).  I identified this as the blocker to be able to load hhvm.hgv.test:8080.

The proxy pass through varnish for domains like cache.hhvm.hgv.test:8080 don't work on an alternate port.  More investigation would be needed for that.