### PR TITLE
Reference new location for user custom config files

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ vagrant_name = File.basename(dir)
 vagrant_version = Vagrant::VERSION.sub(/^v/, '')
 
 default_installs = vagrant_dir + '/provisioning/default-install.yml'
-custom_installs_dir = vagrant_dir + '/hgv_data/config'
+custom_installs_dir = vagrant_dir + '/hgv_data/config/sites'
 
 require 'yaml'
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,6 +43,13 @@ domains_array += domains_from_yml(default_installs)
 Dir.glob( custom_installs_dir + "/*.yml").each do |custom_file|
     domains_array += domains_from_yml(custom_file)
 end
+# Legacy/deprecated file support.  Remove this check in the future.
+Dir.glob( vagrant_dir + '/hgv_data/config/*.yml').each do |custom_file|
+    print "\n*** Custom YML file [ " + custom_file +" ] has been detected ***\n"
+    print "*** DEPRECATED: Please move it to " + custom_installs_dir +"/ ***\n\n"
+    sleep 2
+    domains_array += domains_from_yml(custom_file)
+end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "ubuntu/trusty64"

--- a/bin/custom-sites.sh
+++ b/bin/custom-sites.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This script is invoked by the vagrant provisioner and runs inside the vagrant instance.
-# It provisions the default WordPress install and those based on the YML configuration files found in hgv_data/config/.
+# It provisions the default WordPress install and those based on the YML configuration files found in hgv_data/config/sites/.
 #
 # This script can be run at command line:
 # $ vagrant ssh
@@ -21,7 +21,7 @@ export PYTHONUNBUFFERED=1
 export ANSIBLE_FORCE_COLOR=true
 
 shopt -s nullglob
-for file in /vagrant/provisioning/default-install.yml /vagrant/hgv_data/config/*.yml
+for file in /vagrant/provisioning/default-install.yml /vagrant/hgv_data/config/*.yml /vagrant/hgv_data/config/sites/*.yml
 do
     echo "### Provisioning $file ###"
     $ANS_BIN /vagrant/provisioning/wordpress.yml -i'127.0.0.1,' --extra-vars="@$file"

--- a/bin/mac-linux-custom-sites.sh
+++ b/bin/mac-linux-custom-sites.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This is a helper script around the regular WordPress provisioner that sets up the default WordPress install
-# and those based on the YML configuration files found in hgv_data/config/.
+# and those based on the YML configuration files found in hgv_data/config/sites/.
 #
 # This script can be run at command line:
 # $ bin/mac-linux-custom-sites.sh

--- a/provisioning/default-install.yml
+++ b/provisioning/default-install.yml
@@ -1,4 +1,4 @@
-# DO NOT EDIT: Default WP install and domains for HGV. Instead, copy to a new file under hgv_data/config/.
+# DO NOT EDIT: Default WP install and domains for HGV. Instead, copy to a new file under hgv_data/config/sites/.
 ---
 wp:
   enviro: hhvm

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -17,7 +17,9 @@ The top level of the directory would contain files and directories like so:
 * bin/ - A place for extra scripts used during provisioning of the Vagrant and WordPress'.
 * hgv_data/ -- User owned data. Gets shared/mounted with the Vagrant.
  * sites/ -- Directory containing each WordPress.
- * config/ -- User owned configuration files, example, custom-sites.yml files used for provisioning sites and domains.
+ * config/ -- User owned configuration files
+ *   sites/ -- User owned WordPress configurations, foo.yml, used for provisioning sites and domains.
+ *   provisioning/ansible.yml -- User owned extra variables imported during vagrant up to the ansible provisioning playbook.
 * provisioning/ -- The ansible provisioning code. Do not edit.
  * default-install.yml -- The configuration for the default installed sites and domains. Do not edit.
 
@@ -83,7 +85,7 @@ Installing new plugins and themes is as simple as putting themes in `[HGV direct
 ### The Provision File ###
 Let HGV provision your WordPress for you.
 
-1. Copy provisioning/default-install.yml to hgv_data/config/foo.yml.
+1. Copy provisioning/default-install.yml to hgv_data/config/sites/foo.yml.
 2. Change the `enviro` variable to the docroot of where your WordPress lives under `[HGV directory]/hgv_data/sites/`, ie 'foo'. If the directory does not exist when provisioning is executed, it will be created and the latest stable version or WordPress installed.
 3. Edit the domain lists to be the domain(s) you want setup for the WordPress residing in the Vagrant. Domains listed under `hhvm_domains` will be served by HHVM.  Those listed under `php_domains` will be served by the PHP-FPM service.
 
@@ -91,7 +93,7 @@ If you did not install the vagrant-hostsupdater plugin, you will need to manuall
 
 ### Example ###
 
-hgv_data/config/foo.yml
+hgv_data/config/sites/foo.yml
 
 ```
 ---


### PR DESCRIPTION
*Overview:*
Look for user YAML files in hgv_data/config/sites/*.yml instead of hgv_data/config/*.yml.

*Details:*
It came up in a question a few months ago about organizing the hgv_data/config/ layout.  See https://github.com/wpengine/hgv/issues/197.

Came up when I was working on https://github.com/wpengine/hgv/pull/211.

@ericmann , @stephen-lin is it valuable to change the location where user YAML config files for WP reside?  Do you see where for future work, it would make sense to have those in a folder?

Only used in 2 locations, the rest is documentation.