### PR TITLE
Document the custom-plugins provisioning list

### DIFF
--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -117,6 +117,18 @@ wp:
   multisite: yes
 ```
 
+### Extra Plugins Installed ###
+
+Have plugins that you want installed on disk with your WordPress?  Want that install done automatically when HGV is provisioned? If so, add the *custom_plugins* option to your custom YAML file along with the name of the plugin as it exists in the WordPress repository.  It's that simple.
+
+```
+wp:
+  ...
+  custom_plugins:
+    - akismet
+    - wordpress-seo
+```
+
 ## Admin Tools ##
 HGV contains several useful tools for gathering system state and for administering individual aspects of the system.
 


### PR DESCRIPTION
Add documentation for the user config YAML option 'custom_plugins' which was add in https://github.com/wpengine/hgv/pull/190

- [x] @stephen-lin - Do you like the text of this?