### PR TITLE
Add multisite domain and directory provisioning in ansible

### DIFF
--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -111,12 +111,14 @@ After editing or adding a new configuration, for the changes to take effect, you
 
 ### Multisite ###
 
-If your WordPress is a multisite, it requires certain configurations in the environment to know this is what you want.  So, in your YAML config file, add the *multisite* option and re-provision the vagrant.
+If your WordPress is a multisite, it requires certain configurations in the environment to know this is what you want.  So, in your YAML config file, add the *multisite* option with value 'domain' for subdomain or 'directory' for subdirectory.  Then re-provision the vagrant.
+
+Adding, removing or changing this option does not convert an existing WordPress to or from being a multisite.
 
 ```
 wp:
   ...
-  multisite: yes
+  multisite: domain
 ```
 
 ### Extra Plugins Installed ###

--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -76,7 +76,23 @@
   sudo_user: "{{ web_user }}"
   args:
     chdir: "{{ wp_doc_root }}/{{ enviro }}"
-  when: wpnotinstalled.rc
+  when: wpnotinstalled.rc and ( wp.multisite|default(False) == False )
+
+- name: "Run the multisite WP subdomain install for {{ enviro }}"
+  command: /usr/local/bin/wp core multisite-install --url={{ domain }} --title="WP Engine {{ enviro }} Site" --admin_user=wordpress --admin_password=wordpress --admin_email="admin@example.com" --subdomains
+  sudo: yes
+  sudo_user: "{{ web_user }}"
+  args:
+    chdir: "{{ wp_doc_root }}/{{ enviro }}"
+  when: wpnotinstalled.rc and ( wp.multisite|default(False) == "domain" )
+
+- name: "Run the multisite WP subdirectory install for {{ enviro }}"
+  command: /usr/local/bin/wp core multisite-install --url={{ domain }} --title="WP Engine {{ enviro }} Site" --admin_user=wordpress --admin_password=wordpress --admin_email="admin@example.com"
+  sudo: yes
+  sudo_user: "{{ web_user }}"
+  args:
+    chdir: "{{ wp_doc_root }}/{{ enviro }}"
+  when: wpnotinstalled.rc and ( wp.multisite|default(False) == "directory" )
 
 - name: "Install some useful plugins for {{ enviro }}"
   command: /usr/local/bin/wp plugin install {{ item }}


### PR DESCRIPTION
If the multisite option is present in the user defined hgv_config/sites/foo.yml file, and the WP is not created in the vagrant yet, create the WP.  Also determine if it's to be subdomain or subdirectory and install accordingly.