### PR TITLE
Add support for PHP backend to be specified by cookie

### DIFF
--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -255,11 +255,11 @@ file_upload_max_size: 50
 
 ### Cookie to toggle the backend ###
 
-Don't want to configure different domains for each WordPress' backend processor?  But still want to be able to flip between HHVM and PHP? Have a multisite WordPress which makes it difficult to add domains for each backend processor?
+Don't want to configure both domains for each WordPress' backend processor?  But still want to be able to flip between HHVM and PHP? Have a multisite WordPress which makes it difficult to add domains for each backend processor?
 
 Use a browser cookie to specify the backend. 
 
-The name of the cookie is 'backend'. It accepts values `hhvm` or `php`.  If the cookie does not exist or contains something other than the accepted values, it will be ignored and the mapped domain from the [provision file](/#mercury-vagrant-hgv-add-my-own-wordpress-the-provision-file) will be used.
+The name of the cookie is 'backend'. It accepts values `hhvm` or `php`. If the cookie does not exist or contains something other than the accepted values, it will be ignored and the mapped domain from the [provision file](/#mercury-vagrant-hgv-add-my-own-wordpress-the-provision-file) will be used.
 
 This is specific to the HGV development environment.  This cookie feature is not available for Mercury production.
 

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -253,6 +253,18 @@ This is an example of changing the max file upload size allowed by Nginx, HHVM, 
 file_upload_max_size: 50
 ```
 
+### Cookie to toggle the backend ###
+
+Don't want to configure different domains for each WordPress' backend processor?  But still want to be able to flip between HHVM and PHP? Have a multisite WordPress which makes it difficult to add domains for each backend processor?
+
+Use a browser cookie to specify the backend. 
+
+The name of the cookie is 'backend'. It accepts values `hhvm` or `php`.  If the cookie does not exist or contains something other than the accepted values, it will be ignored and the mapped domain from the [provision file](/#mercury-vagrant-hgv-add-my-own-wordpress-the-provision-file) will be used.
+
+This is specific to the HGV development environment.  This cookie feature is not available for Mercury production.
+
+**TODO:** Add a drop in plugin that allows the user to toggle the cookie via the HGV dashbaord or in WP Admin for a site.
+
 ## FAQs ##
 
 ### General FAQs ###

--- a/provisioning/roles/wordpress/templates/etc/nginx/conf.d/wordpress.conf
+++ b/provisioning/roles/wordpress/templates/etc/nginx/conf.d/wordpress.conf
@@ -1,9 +1,18 @@
 # During vagrant provisioning, this map of domains to the backend PHP processor is populated
-map $host $upstream_target_{{ enviro }} {
+map $host $upstream_by_domain_{{ enviro }} {
     hostnames;
 
     ## Upstream for {{ enviro }} ## After this line, domains are inserted by the provisioning scripts. Do Not Edit.
 
+}
+
+# During vagrant provisioning, this map to the backend PHP processor is populated
+# If there is no cookie 'backend' or it's value doesn't match any of those specified,
+# it will resolve to use the value of the variable $upstream_by_domain_... from the map above.
+map $cookie_backend $upstream_target_{{ enviro }} {
+    default $upstream_by_domain_{{ enviro }};
+    hhvm    hhvm;
+    php    php;
 }
 
 # The server block for the non-varnish cached domains

--- a/test/codeception/tests/acceptance.suite.yml
+++ b/test/codeception/tests/acceptance.suite.yml
@@ -9,6 +9,10 @@ modules:
     enabled:
         - PhpBrowser
         - \Helper\Acceptance
+        - Filesystem
+        - Asserts
+        - REST:
+            depends: PhpBrowser
     config:
         PhpBrowser:
             url: 'http://hgv.dev/'

--- a/test/codeception/tests/acceptance/MultisiteDirectoryCest.php
+++ b/test/codeception/tests/acceptance/MultisiteDirectoryCest.php
@@ -15,6 +15,15 @@ class MultisiteDirectoryCest
     public function viewPageHHVM(AcceptanceTester $I)
     {
         $I->amOnUrl('http://multidirectory.test');
+        // Check the backend processor is what we expected
+        $I->assertRegExp('#HHVM/(.*)#', $I->grabHttpHeader('X-Powered-By'));
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewSubpageHHVM(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://multidirectory.test');
+        $I->assertRegExp('#HHVM/(.*)#', $I->grabHttpHeader('X-Powered-By'));
         $I->amOnPage('/foo/');
         $I->seeCurrentUrlEquals('/foo/');
         $I->seeResponseCodeIs(200);
@@ -22,7 +31,19 @@ class MultisiteDirectoryCest
 
     public function viewPagePHP(AcceptanceTester $I)
     {
-        $I->amOnUrl('http://phpmultidirectory.test');
+        // Pass header/cookie to specify the backend
+        $I->setCookie('backend', 'php');
+        $I->amOnUrl('http://multidirectory.test');
+        $I->assertRegExp('#PHP/(.*)#', $I->grabHttpHeader('X-Powered-By'));
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewSubpagePHP(AcceptanceTester $I)
+    {
+        // Pass header/cookie to specify the backend
+        $I->setCookie('backend', 'php');
+        $I->amOnUrl('http://multidirectory.test');
+        $I->assertRegExp('#PHP/(.*)#', $I->grabHttpHeader('X-Powered-By'));
         $I->amOnPage('/foo/');
         $I->seeCurrentUrlEquals('/foo/');
         $I->seeResponseCodeIs(200);
@@ -37,7 +58,10 @@ class MultisiteDirectoryCest
 
     public function viewPagePHP404(AcceptanceTester $I)
     {
-        $I->amOnUrl('http://phpmultidirectory.test');
+        // Pass header/cookie to specify the backend
+        $I->setCookie('backend', 'php');
+        $I->amOnUrl('http://multidirectory.test');
+        $I->assertRegExp('#PHP/(.*)#', $I->grabHttpHeader('X-Powered-By'));
         $I->amOnPage('/bar');
         $I->seeResponseCodeIs(404);
     }


### PR DESCRIPTION
Allow a cookie to specify the backend PHP processor (HHVM/PHP-FPM) in lieu of the nginx domain mapping.  If the cookie is not present or conains a value other than hhvm or php, then it is ignored and the domain mapping as it works today, is used.

Fix to original issue https://github.com/wpengine/hgv/issues/182.

Test: Specify the 'backend' cookie on command line curl and check the backend powered-by header.

curl 'http://hhvm.hgv.test/' --cookie "backend=hhvm" -I --silent | grep Powered
This should return "X-Powered-By: HHVM/x.x.x"

curl 'http://hhvm.hgv.test/' --cookie "backend=php" -I --silent | grep Powered
This should return "X-Powered-By: PHP/5.5.9-1ubuntu4.11"

Requires 'vagrant provision' to push the change into the Nginx config files found at /etc/nginx/conf.d/www-*.

We'll need to change some documentation and maybe an FAQ in the wiki.

(Note: These codeception tests pass, but only after some multisite setup for those WP installs.  I have commands to set those up that I need to cleanup and submit.)