### PR TITLE
Remove references to hgv.dev in favor of hgv.test

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,46 +76,46 @@ Once Vagrant is done provisioning the VM, you will have a box running Ubuntu 14.
 * [Memcached](http://memcached.org)
 
 ## Next Steps ##
-Once the VM is done provisioning, direct your browser to [http://hgv.dev](http://hgv.dev) You will receive fuller instructions on the use of this Vagrant environment there.
+Once the VM is done provisioning, direct your browser to [http://hgv.test](http://hgv.test) You will receive fuller instructions on the use of this Vagrant environment there.
 
 ### Once Installed These Local URLs / SITES Contain Great Documentation ###
 No really, make sure you go to these to check them out as you work with HGV. HGV automatically creates four sites and adds host file entries for them (if you installed the `vagrant-ghost` plugin, that is):
 
-* [hgv.dev](http://hgv.dev) -- General documentation and links for all of the tools
-* [hhvm.hgv.dev](http://hhvm.hgv.dev) -- A new WordPress installation running on HHVM
-* [php.hgv.dev](http://php.hgv.dev) -- A new WordPress installation running on PHP-FPM (PHP 5.5)
-* [admin.hgv.dev](http://admin.hgv.dev) -- Useful administrative tools (phpMyAdmin, etc.)
+* [hgv.test](http://hgv.test) -- General documentation and links for all of the tools
+* [hhvm.hgv.test](http://hhvm.hgv.test) -- A new WordPress installation running on HHVM
+* [php.hgv.test](http://php.hgv.test) -- A new WordPress installation running on PHP-FPM (PHP 5.5)
+* [admin.hgv.test](http://admin.hgv.test) -- Useful administrative tools (phpMyAdmin, etc.)
 
 If you did not install the `vagrant-ghost` plugin, you will need to manually [add](http://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/) the following host entries to your host operating system's host files:
 
 ```conf
-192.168.150.20 hgv.dev
-192.168.150.20 admin.hgv.dev
-192.168.150.20 hhvm.hgv.dev
-192.168.150.20 php.hgv.dev
-192.168.150.20 cache.hhvm.hgv.dev
-192.168.150.20 cache.php.hgv.dev
-192.168.150.20 xhprof.hgv.dev
+192.168.150.20 hgv.test
+192.168.150.20 admin.hgv.test
+192.168.150.20 hhvm.hgv.test
+192.168.150.20 php.hgv.test
+192.168.150.20 cache.hhvm.hgv.test
+192.168.150.20 cache.php.hgv.test
+192.168.150.20 xhprof.hgv.test
 ```
 
 ## Using URLs to View Different Stacks Running Your Code ##
 
 There are two default WordPress installations provided. Both have an admin user *wordpress* with a password *wordpress* (so secure!) already created.
 
-### php.hgv.dev ###
+### php.hgv.test ###
 
-[php.hgv.dev](http://php.hgv.dev) is a basic WordPress install running the latest stable version of WordPress on a fairly standard [LEMP](https://lemp.io/) stack consisting of Nginx, PHP-FPM, and Percona DB.
+[php.hgv.test](http://php.hgv.test) is a basic WordPress install running the latest stable version of WordPress on a fairly standard [LEMP](https://lemp.io/) stack consisting of Nginx, PHP-FPM, and Percona DB.
 
-### hhvm.hgv.dev ###
+### hhvm.hgv.test ###
 
-[hhvm.hgv.dev](http://hhvm.hgv.dev) is a basic WordPress install running the latest stable version of WordPress on top of an Nginx + HHVM + Percona DB stack.
+[hhvm.hgv.test](http://hhvm.hgv.test) is a basic WordPress install running the latest stable version of WordPress on top of an Nginx + HHVM + Percona DB stack.
 
 ### Varnish Testing ###
 
 The following URLs will let you view a specific page with caching turned on to test for dynamic content performance.
 
-* [cache.php.hgv.dev](http://cache.php.hgv.dev)
-* [cache.hhvm.hgv.dev](http://cache.hhvm.hgv.dev)
+* [cache.php.hgv.test](http://cache.php.hgv.test)
+* [cache.hhvm.hgv.test](http://cache.hhvm.hgv.test)
 
 ## Development and debugging ##
 ### WordPress developer tools ###
@@ -157,7 +157,7 @@ Sometimes, keeping tabs on a log file while hitting a site to view log messages 
 
 ### Database access ###
 
-You may easily use the phpMyAdmin installation at [admin.hgv.dev/phpmyadmin/](http://admin.hgv.dev/phpmyadmin/) (as listed above) in order to view and interact with the underlying database. However, if you are used to using a third-party GUI, such as [Sequel Pro](http://www.sequelpro.com/) or [MySQL Workbench](http://www.mysql.com/products/workbench/), TCP port 3306 (the MySQL/Percona port) is forwarded from the Vagrant VM to TCP port 23306 on your actual machine. You would then configure MySQL WB or Sequel Pro to connect to `localhost:23306` .
+You may easily use the phpMyAdmin installation at [admin.hgv.test/phpmyadmin/](http://admin.hgv.test/phpmyadmin/) (as listed above) in order to view and interact with the underlying database. However, if you are used to using a third-party GUI, such as [Sequel Pro](http://www.sequelpro.com/) or [MySQL Workbench](http://www.mysql.com/products/workbench/), TCP port 3306 (the MySQL/Percona port) is forwarded from the Vagrant VM to TCP port 23306 on your actual machine. You would then configure MySQL WB or Sequel Pro to connect to `localhost:23306` .
 
 ### Developer tools ###
 
@@ -178,7 +178,7 @@ The following useful developer tools are installed by default:
 
 ### Xdebug ###
 
-PHP's [Xdebug extension](http://xdebug.org) is installed by default for the site based on PHP-FPM.  See the [dashboard](http://hgv.dev/) for details about the features that are enabled by default for each WordPress.
+PHP's [Xdebug extension](http://xdebug.org) is installed by default for the site based on PHP-FPM.  See the [dashboard](http://hgv.test/) for details about the features that are enabled by default for each WordPress.
 
 Xdebug browser extensions to toggle Xdebug on/off without having to ssh into the virtual machine:
 * [Safari - Xdebug Toggler] (https://github.com/benmatselby/xdebug-toggler)
@@ -186,17 +186,17 @@ Xdebug browser extensions to toggle Xdebug on/off without having to ssh into the
 * [Chrome - Xdebug Helper] (https://chrome.google.com/webstore/detail/xdebug-helper/eadndfjplgieldjbigjakmdgkmoaaa)
 
 ### XHProf ###
-HGV includes an advanced PHP/HHVM profiling tool, [http://php.net/xhprof](http://php.net/xhprof) and a GUI for viewing results. You can view results for your HGV instance at [xhprof.hgv.dev](http://xhprof.hgv.dev).  See the [dashboard](http://hgv.dev/) for details about how easy it is to turn on profiling by adding one parameter to your page request in the browser.
+HGV includes an advanced PHP/HHVM profiling tool, [http://php.net/xhprof](http://php.net/xhprof) and a GUI for viewing results. You can view results for your HGV instance at [xhprof.hgv.test](http://xhprof.hgv.test).  See the [dashboard](http://hgv.test/) for details about how easy it is to turn on profiling by adding one parameter to your page request in the browser.
 
 ### Database ###
-phpMyAdmin is available at [admin.hgv.dev/phpmyadmin/](http://admin.hgv.dev/phpmyadmin/). The username is `root` and the password is blank.
+phpMyAdmin is available at [admin.hgv.test/phpmyadmin/](http://admin.hgv.test/phpmyadmin/). The username is `root` and the password is blank.
 
 ### Object Cache/Memcached ###
 
-phpMemcachedAdmin is available at [admin.hgv.dev/phpmemcachedadmin/](http://admin.hgv.dev/phpmemcachedadmin/). You may use this tool to check on the status of the WordPress object [cache](http://codex.wordpress.org/Class_Reference/WP_Object_Cache).
+phpMemcachedAdmin is available at [admin.hgv.test/phpmemcachedadmin/](http://admin.hgv.test/phpmemcachedadmin/). You may use this tool to check on the status of the WordPress object [cache](http://codex.wordpress.org/Class_Reference/WP_Object_Cache).
 
 ### Log Viewing ###
-PML is available at [admin.hgv.dev/logs](http://admin.hgv.dev/logs). You may use this tool to quickly view the most recent web server access and error logs for the various sites automatically created by HGV.
+PML is available at [admin.hgv.test/logs](http://admin.hgv.test/logs). You may use this tool to quickly view the most recent web server access and error logs for the various sites automatically created by HGV.
 
 ## More Documentation/Information ##
 
@@ -212,7 +212,7 @@ README.md - This README markdown file, the technical steps of how to get up and 
 
 [updates](http://wpengine.com/mercury/updates) - Another place where the WP Engine team will go into detail about releases or updates to HGV.
 
-[dashboard](http://hgv.dev) - The local HGV dashboard which is available when your vagrant is up and running. This contains all the technical details and configuration options specific to the HGV environment.
+[dashboard](http://hgv.test) - The local HGV dashboard which is available when your vagrant is up and running. This contains all the technical details and configuration options specific to the HGV environment.
 
 For detailed how to install guides per OS and other debugging information please see the [wiki here on github](https://github.com/wpengine/hgv/wiki).
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ custom_installs_dir = vagrant_dir + '/hgv_data/config/sites'
 
 require 'yaml'
 
-domains_array = ['hgv.dev', 'admin.hgv.dev', 'xhprof.hgv.dev', 'mail.hgv.dev', 'admin.hgv.test', 'xhprof.hgv.test', 'mail.hgv.test']
+domains_array = ['admin.hgv.test', 'xhprof.hgv.test', 'mail.hgv.test']
 
 def domains_from_yml(file)
     ret = []

--- a/provisioning/default-install.yml
+++ b/provisioning/default-install.yml
@@ -3,8 +3,6 @@
 wp:
   enviro: hhvm
   hhvm_domains:
-    - hhvm.hgv.dev
     - hhvm.hgv.test
   php_domains:
-    - php.hgv.dev
     - php.hgv.test

--- a/provisioning/roles/admin/files/etc/nginx/conf.d/mail.conf
+++ b/provisioning/roles/admin/files/etc/nginx/conf.d/mail.conf
@@ -1,10 +1,10 @@
 server {
         listen          80;
-        server_name     mail.hgv.dev mail.hgv.test;
+        server_name     mail.hgv.test;
 
-        access_log  /var/log/nginx/mail.hgv.dev.access.log  wpengine;
-        access_log  /var/log/nginx/mail.hgv.dev.apachestyle.access.log  apachestandard;
-        error_log  /var/log/nginx/mail.hgv.dev.error.log warn;
+        access_log  /var/log/nginx/mail.hgv.test.access.log  wpengine;
+        access_log  /var/log/nginx/mail.hgv.test.apachestyle.access.log  apachestandard;
+        error_log  /var/log/nginx/mail.hgv.test.error.log warn;
 
         location / {
                 proxy_set_header Host $host;

--- a/provisioning/roles/admin/templates/etc/nginx/conf.d/admin.conf
+++ b/provisioning/roles/admin/templates/etc/nginx/conf.d/admin.conf
@@ -1,12 +1,12 @@
 server {
        listen   {{ nginx_listen_port }};
-       server_name admin.hgv.dev admin.hgv.test;
+       server_name admin.hgv.test;
        root /nas/wp/www/sites/admin;
 
        index index.php index.html;
-       access_log  /var/log/nginx/admin.hgv.dev.access.log  wpengine;
-       access_log  /var/log/nginx/admin.hgv.dev.apachestyle.access.log  apachestandard;
-       error_log  /var/log/nginx/admin.hgv.dev.error.log warn;
+       access_log  /var/log/nginx/admin.hgv.test.access.log  wpengine;
+       access_log  /var/log/nginx/admin.hgv.test.apachestyle.access.log  apachestandard;
+       error_log  /var/log/nginx/admin.hgv.test.error.log warn;
 
        location = /favicon.ico {
                 log_not_found off;

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -32,7 +32,7 @@
   get_url: url=https://github.com/d11wtq/boris/releases/download/v1.0.8/boris.phar dest=/usr/local/bin/boris mode=0755 validate_certs=no
 
 - name: Set up host entries
-  lineinfile: dest=/etc/hosts line="127.0.0.1 hhvm.hgv.dev php.hgv.dev cache.php.hgv.dev cache.hhvm.hgv.dev admin.hgv.dev"
+  lineinfile: dest=/etc/hosts line="127.0.0.1 hhvm.hgv.test php.hgv.test cache.php.hgv.test cache.hhvm.hgv.test admin.hgv.test"
 
 - name: Get PHPUnit
   get_url: url=https://phar.phpunit.de/phpunit.phar dest=/usr/local/bin/phpunit mode=0755 validate_certs=no

--- a/provisioning/roles/nginx/templates/etc/nginx/conf.d/dashboard.conf
+++ b/provisioning/roles/nginx/templates/etc/nginx/conf.d/dashboard.conf
@@ -1,9 +1,15 @@
 server {
         listen   {{ nginx_listen_port }} default;
-        server_name  _ hgv.dev hgv.test;
+        server_name  _ hgv.test;
         root {{ wp_doc_root }}/dashboard;
 
         location / {
                 try_files $uri $uri/ /index.html;
         }
+}
+# Redirect the old dashboard url to new
+server {
+        listen   {{ nginx_listen_port }};
+        server_name  hgv.dev;
+        return 301 http://hgv.test$request_uri;
 }

--- a/provisioning/roles/nginx/templates/etc/nginx/conf.d/upstream.conf
+++ b/provisioning/roles/nginx/templates/etc/nginx/conf.d/upstream.conf
@@ -20,9 +20,9 @@ server {
         # Set the doc root for the WP from information provided downstream
         root {{ wp_doc_root }}/$http_x_wp_enviro;
 
-        access_log  /var/log/nginx/varnish.hgv.dev.access.log  wpengine;
-        access_log  /var/log/nginx/varnish.hgv.dev.apachestyle.access.log  apachestandard;
-        error_log  /var/log/nginx/varnish.hgv.dev.error.log warn;
+        access_log  /var/log/nginx/varnish.hgv.test.access.log  wpengine;
+        access_log  /var/log/nginx/varnish.hgv.test.apachestyle.access.log  apachestandard;
+        error_log  /var/log/nginx/varnish.hgv.test.error.log warn;
 
         include /etc/nginx/fastcgi_params;
 

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/admin/index.php
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/admin/index.php
@@ -1,2 +1,2 @@
 <?php
-header('Location: http://admin.hgv.dev/phpmyadmin');
+header('Location: http://admin.hgv.test/phpmyadmin');

--- a/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
+++ b/provisioning/roles/nginx/templates/nas/wp/www/sites/dashboard/GETTINGSTARTED.md
@@ -36,20 +36,20 @@ Once Vagrant is done provisioning the VM, you will have a box running [Ubuntu 14
 ### Sites ###
 HGV automatically creates four sites and adds host file entries for them (*if you installed the `vagrant-ghost` plugin, that is*):
 
-* [hgv.dev](http://hgv.dev) -- General documentation and links for all of the tools
-* [hhvm.hgv.dev](http://hhvm.hgv.dev) -- A new WordPress installation running on HHVM
-* [php.hgv.dev](http://php.hgv.dev) -- A new WordPress installation running on PHP-FPM (PHP 5.5)
-* [admin.hgv.dev](http://admin.hgv.dev) -- Useful administrative tools (phpMyAdmin, etc.)
+* [hgv.test](http://hgv.test) -- General documentation and links for all of the tools
+* [hhvm.hgv.test](http://hhvm.hgv.test) -- A new WordPress installation running on HHVM
+* [php.hgv.test](http://php.hgv.test) -- A new WordPress installation running on PHP-FPM (PHP 5.5)
+* [admin.hgv.test](http://admin.hgv.test) -- Useful administrative tools (phpMyAdmin, etc.)
 
 If you did *not* install the `vagrant-ghost` plugin, you will need to manually [add](http://www.howtogeek.com/howto/27350/beginner-geek-how-to-edit-your-hosts-file/) the following host entries to your host operating system's host files:
 
 ```
-192.168.150.20 hgv.dev
-192.168.150.20 admin.hgv.dev
-192.168.150.20 hhvm.hgv.dev
-192.168.150.20 php.hgv.dev
-192.168.150.20 cache.hhvm.hgv.dev
-192.168.150.20 cache.php.hgv.dev
+192.168.150.20 hgv.test
+192.168.150.20 admin.hgv.test
+192.168.150.20 hhvm.hgv.test
+192.168.150.20 php.hgv.test
+192.168.150.20 cache.hhvm.hgv.test
+192.168.150.20 cache.php.hgv.test
 ```
 
 ## WordPress Installations ##
@@ -57,11 +57,11 @@ If you did *not* install the `vagrant-ghost` plugin, you will need to manually [
 ### Default Installs ###
 There is one default WordPress installation provided and accessible at two domains. The provisioning details for this WordPress can be found in the file `provisioning/default-install.yml`.
 
-#### hhvm.hgv.dev ####
-[hhvm.hgv.dev](http://hhvm.hgv.dev) is a basic WordPress install running the latest stable version of WordPress on top of an Nginx + HHVM + Percona DB stack.
+#### hhvm.hgv.test ####
+[hhvm.hgv.test](http://hhvm.hgv.test) is a basic WordPress install running the latest stable version of WordPress on top of an Nginx + HHVM + Percona DB stack.
 
-#### php.hgv.dev ####
-[php.hgv.dev](http://php.hgv.dev) is a basic WordPress install running the latest stable version of WordPress on a fairly standard [LEMP stack](https://lemp.io/) consisting of Nginx, PHP-FPM and Percona DB.
+#### php.hgv.test ####
+[php.hgv.test](http://php.hgv.test) is a basic WordPress install running the latest stable version of WordPress on a fairly standard [LEMP stack](https://lemp.io/) consisting of Nginx, PHP-FPM and Percona DB.
 
 ### Database Access ###
 Both have an admin user `wordpress` with a password `wordpress` (so secure!) already created.
@@ -137,10 +137,10 @@ wp:
 HGV contains several useful tools for gathering system state and for administering individual aspects of the system.
 
 ### Database ###
-phpMyAdmin is available at [admin.hgv.dev/phpmyadmin/](http://admin.hgv.dev/phpmyadmin/). The username is `root` and the  password is blank.
+phpMyAdmin is available at [admin.hgv.test/phpmyadmin/](http://admin.hgv.test/phpmyadmin/). The username is `root` and the  password is blank.
 
 ### Object Cache/Memcached ###
-phpMemcachedAdmin is available at [admin.hgv.dev/phpmemcachedadmin/](http://admin.hgv.dev/phpmemcachedadmin/). You may use this tool to check on the status of the WordPress [object cache](http://codex.wordpress.org/Class_Reference/WP_Object_Cache).
+phpMemcachedAdmin is available at [admin.hgv.test/phpmemcachedadmin/](http://admin.hgv.test/phpmemcachedadmin/). You may use this tool to check on the status of the WordPress [object cache](http://codex.wordpress.org/Class_Reference/WP_Object_Cache).
 
 ## Development and debugging ##
 ### Command line (CLI) access ###
@@ -178,18 +178,18 @@ Once you are connected to the HGV virtual machine, system and web server logs ca
 
 Web server logs are stored in `/var/log/nginx`, with separate log files for every site. Each site has several log files associated with it:
 
-* `[site].hgv.dev.access.log`
-* `[site].hgv.dev.apachestyle.access.log`
-* `[site].hgv.dev.error.log`
+* `[enviro].access.log`
+* `[enviro].apachestyle.access.log`
+* `[enviro].error.log`
 
 The first two logs track web requests to the sites, while the third log tracks errors reported, both by Nginx and by "upstream" PHP and HHVM processes.
 
 HHVM logs are in `/var/log/hhvm`. PHP-FPM writes all of its logging information into `/var/log/php5-fpm.log`.
 
-Sometimes, keeping tabs on a log file while hitting a site to view log messages in real-time can be helpful. To do so, run `sudo tail -f [log file]` from your SSH session. For example, `sudo tail -f /var/log/nginx/php.hgv.dev.error.log` would give you an always-updating view of the error log file for the PHP-FPM-based site.
+Sometimes, keeping tabs on a log file while hitting a site to view log messages in real-time can be helpful. To do so, run `sudo tail -f [log file]` from your SSH session. For example, `sudo tail -f /var/log/nginx/[enviro].error.log` would give you an always-updating view of the error log file for the site.
 
 ### Database access ###
-You may easily use the phpMyAdmin installation at [admin.hgv.dev/phpmyadmin/](http://admin.hgv.dev/phpmyadmin/) (as listed above) in order to view and interact with the underlying database. However, if you are used to using a third-party GUI, such as
+You may easily use the phpMyAdmin installation at [admin.hgv.test/phpmyadmin/](http://admin.hgv.test/phpmyadmin/) (as listed above) in order to view and interact with the underlying database. However, if you are used to using a third-party GUI, such as
 [Sequel Pro](http://www.sequelpro.com/) or [MySQL Workbench](http://www.mysql.com/products/workbench/), TCP port 3306 (the MySQL/Percona port) is forwarded from the Vagrant VM to TCP port 23306 on your actual machine. You would then configure MySQL WB or Sequel Pro to connect to `localhost:23306`.
 
 ### Developer tools ###
@@ -221,19 +221,19 @@ define('SAVEQUERIES', true);
 Enabling the Query Monitor WordPress plugin will allow logged-in users to view the useful debug information output by Xdebug, such as number of queries, number of objects, page render time, etc.
 
 ### XHProf ###
-HGV includes an advanced PHP/HHVM profiling tool, [http://php.net/xhprof](http://php.net/xhprof) and a GUI for viewing results. You can view results for your HGV instance at [xhprof.hgv.dev](http://xhprof.hgv.dev).  
+HGV includes an advanced PHP/HHVM profiling tool, [http://php.net/xhprof](http://php.net/xhprof) and a GUI for viewing results. You can view results for your HGV instance at [xhprof.hgv.test](http://xhprof.hgv.test).  
 
 Initially, there will be no profiling data -- you'll need to enable profiling for the various HGV sites. You can enable profiling by passing `_profile=1` to any PHP request on the host. To get started, visit:
 
-* [http://php.hgv.dev/?_profile=1](http://php.hgv.dev/?_profile=1)
-* [http://hhvm.hgv.dev/?_profile=1](http://hhvm.hgv.dev/?_profile=1)
+* [http://php.hgv.test/?_profile=1](http://php.hgv.test/?_profile=1)
+* [http://hhvm.hgv.test/?_profile=1](http://hhvm.hgv.test/?_profile=1)
 
-Passing the `_profile=1` argument to the sites causes XHProf to set a cookie. While this cookie is active, XHProf will attempt to profile all of your page views. Visit a few URLs on your PHP and HHVM sites, then visit [xhprof.hgv.dev](http://xhprof.hgv.dev) again. You should see profiling results displayed for your interactions with the sites.
+Passing the `_profile=1` argument to the sites causes XHProf to set a cookie. While this cookie is active, XHProf will attempt to profile all of your page views. Visit a few URLs on your PHP and HHVM sites, then visit [xhprof.hgv.test](http://xhprof.hgv.test) again. You should see profiling results displayed for your interactions with the sites.
 
 When you want to disable profiling, simply append `_profile=0` to any request, or visit these links:
 
-* [http://php.hgv.dev/?_profile=0](http://php.hgv.dev/?_profile=0)
-* [http://hhvm.hgv.dev/?_profile=0](http://hhvm.hgv.dev/?_profile=0)
+* [http://php.hgv.test/?_profile=0](http://php.hgv.test/?_profile=0)
+* [http://hhvm.hgv.test/?_profile=0](http://hhvm.hgv.test/?_profile=0)
 
 Visiting those links should delete the cookie and disable XHProf.
 

--- a/provisioning/roles/xhprof/templates/etc/nginx/conf.d/xhprof.conf
+++ b/provisioning/roles/xhprof/templates/etc/nginx/conf.d/xhprof.conf
@@ -1,10 +1,10 @@
 server {
     listen   {{ nginx_listen_port }};
-    server_name  xhprof.hgv.dev xhprof.hgv.test;
+    server_name  xhprof.hgv.test;
     root /opt/xhprof/xhprof_html;
-    access_log  /var/log/nginx/xhprof.hgv.dev.access.log  wpengine;
-    access_log  /var/log/nginx/xhprof.hgv.dev.apachestyle.access.log  apachestandard;
-    error_log  /var/log/nginx/xhprof.hgv.dev.error.log warn;
+    access_log  /var/log/nginx/xhprof.hgv.test.access.log  wpengine;
+    access_log  /var/log/nginx/xhprof.hgv.test.apachestyle.access.log  apachestandard;
+    error_log  /var/log/nginx/xhprof.hgv.test.error.log warn;
 
     index index.php;
     location / {

--- a/test/codeception/tests/acceptance.suite.yml
+++ b/test/codeception/tests/acceptance.suite.yml
@@ -15,4 +15,4 @@ modules:
             depends: PhpBrowser
     config:
         PhpBrowser:
-            url: 'http://hgv.dev/'
+            url: 'http://hgv.test/'

--- a/test/codeception/tests/acceptance/DashboardCest.php
+++ b/test/codeception/tests/acceptance/DashboardCest.php
@@ -1,0 +1,41 @@
+<?php
+use \AcceptanceTester;
+
+class DashboardCest
+{
+    public function _before(AcceptanceTester $I)
+    {
+    }
+
+    public function _after(AcceptanceTester $I)
+    {
+    }
+
+    // tests
+    // Check that the dashboard doesn't contain legacy url
+    public function home(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://hgv.test');
+    }
+
+    public function viewAdmin(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://admin.hgv.test');
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewPhpmyadmin(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://admin.hgv.test/phpmyadmin');
+        $I->seeResponseCodeIs(200);
+        $I->see('Welcome to <bdo dir="ltr" lang="en">phpMyAdmin</bdo>');
+    }
+
+    public function viewPhpmemcachedadmin(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://admin.hgv.test/phpmemcachedadmin');
+        $I->seeResponseCodeIs(200);
+        $I->see('phpMemcachedAdmin', '//head/title');
+    }
+
+}

--- a/test/codeception/tests/acceptance/DefaultWPCest.php
+++ b/test/codeception/tests/acceptance/DefaultWPCest.php
@@ -21,9 +21,25 @@ class DefaultWPCest
         $I->seeResponseCodeIs(200);
     }
 
+    public function viewPageHHVMcache(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://cache.hhvm.hgv.test');
+        $I->amOnPage('/');
+        $I->seeCurrentUrlEquals('/');
+        $I->seeResponseCodeIs(200);
+    }
+
     public function viewPagePHP(AcceptanceTester $I)
     {
         $I->amOnUrl('http://php.hgv.test');
+        $I->amOnPage('/');
+        $I->seeCurrentUrlEquals('/');
+        $I->seeResponseCodeIs(200);
+    }
+
+    public function viewPagePHPcache(AcceptanceTester $I)
+    {
+        $I->amOnUrl('http://cache.php.hgv.test');
         $I->amOnPage('/');
         $I->seeCurrentUrlEquals('/');
         $I->seeResponseCodeIs(200);


### PR DESCRIPTION
Fully remove support for http://hgv.dev url.  Solves https://github.com/wpengine/hgv/issues/98

Most of this is update to documentation.  Stops listening to hgv.dev domains.