### PR TITLE
Force the Mailhog init script to use LF line endings on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 
 # Explicitly declare files that will always have LF line endings on checkout
 *.key text eol=lf
+mailhog_init text eol=lf


### PR DESCRIPTION
Fixes #239