### PR TITLE
Moved the error-page to inside the plugin

### DIFF
--- a/provisioning/roles/admin/tasks/main.yml
+++ b/provisioning/roles/admin/tasks/main.yml
@@ -181,7 +181,3 @@
 - name: Setup hhvminfo.php
   template: src=hhvminfo.php dest={{ wp_doc_root }}/admin/hhvminfo.php owner={{ web_user }} group={{ web_group }}
   tags: [ 'admin', 'info' ]
-
-- name: Add the PHP cookie error page
-  template: src=error-page.html dest={{ wp_doc_root }}/admin/error-page.html owner={{ web_user }} group={{ web_group }}
-  tags: [ 'admin' ]


### PR DESCRIPTION
Forgot to remove this when I moved the html page to part of the plugin.