### PR TITLE
Force LF line endings on *.sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 
 # Explicitly declare files that will always have LF line endings on checkout
 *.key text eol=lf
+*.sh text eol=lf
 mailhog_init text eol=lf


### PR DESCRIPTION
With the merge of PHP7 support, we've added some .sh scripts to the
provisioning process to build various tools. These scripts need to force
LF line endings through the .gitattributes file otherwise Windows clones
will muck with the file and break provisioning.

Fixes #256