### PR TITLE
Change XHProf profiler output url

### DIFF
--- a/provisioning/roles/xhprof/templates/config.php
+++ b/provisioning/roles/xhprof/templates/config.php
@@ -10,7 +10,7 @@ $_xhprof['dbname'] = 'xhprof';
 $_xhprof['dbadapter'] = 'Pdo';
 $_xhprof['servername'] = 'myserver';
 $_xhprof['namespace'] = 'myapp';
-$_xhprof['url'] = 'http://url/to/xhprof/xhprof_html';
+$_xhprof['url'] = 'http://xhprof.hgv.test';                                                         
 /*
  * MySQL/MySQLi/PDO ONLY
  * Switch to JSON for better performance and support for larger profiler data sets.


### PR DESCRIPTION
Update the url for the profiler output added to the page footer to point to the default XHProf location.

- [x] @markkelnar
- [x] @ericmann