### PR TITLE
Fatal error when php_domains is empty

### DIFF
--- a/provisioning/wordpress.yml
+++ b/provisioning/wordpress.yml
@@ -9,7 +9,7 @@
         role: wordpress,
         enviro: "{{ wp.enviro }}",
         domain: "{{ wp.hhvm_domains[0] }}",
-        domains: "{{ wp.hhvm_domains }} + {{ wp.php_domains }}",
+        domains: "{{ wp.hhvm_domains }} + {{ wp.php_domains|default('') }}",
         mysql_import: "{{ wp.mysql_import | default(False) }}",
         mysql_backup: "{{ wp.mysql_backup | default(False) }}",
         tags: [ 'wordpress' ]

--- a/provisioning/wordpress.yml
+++ b/provisioning/wordpress.yml
@@ -9,7 +9,7 @@
         role: wordpress,
         enviro: "{{ wp.enviro }}",
         domain: "{{ wp.hhvm_domains[0] }}",
-        domains: "{{ wp.hhvm_domains }} + {{ wp.php_domains|default('') }}",
+        domains: "{{ wp.hhvm_domains }} + {{ wp.php_domains|default([]) }}",
         mysql_import: "{{ wp.mysql_import | default(False) }}",
         mysql_backup: "{{ wp.mysql_backup | default(False) }}",
         tags: [ 'wordpress' ]


### PR DESCRIPTION
As suggested by @zamoose, this is the fix for https://github.com/wpengine/hgv/issues/262

