### PR TITLE
[BUG] Remove errand unused variable leftover after a refactor

### DIFF
--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -118,7 +118,7 @@
   template: src=etc/nginx/conf.d/wordpress.conf dest=/etc/nginx/conf.d/www-{{ enviro }}.conf owner=root group=root mode=0644
   notify: nginx reload
 
-- name: "Enable PML viewing for {{ enviro }} {{ backend }}"
+- name: "Enable PML viewing for {{ enviro }}"
   template: src=pimpmylog.json dest={{ wp_doc_root }}/admin/logs/config.user.d/{{ enviro }}.json
   with_items:
     - "{{ domain }}"


### PR DESCRIPTION
Fix for fatal error.

https://github.com/wpengine/hgv/issues/287

It was introduced a while ago here https://github.com/wpengine/hgv/commit/62d41e1054784c5853e15fb675b883bb4f4bc4f2#diff-3a119c73616b2c22a946365022dff648R98

