### PR TITLE
Temporary fix for HHVM 3.13.0 bug

### DIFF
--- a/provisioning/roles/hhvm/tasks/main.yml
+++ b/provisioning/roles/hhvm/tasks/main.yml
@@ -3,10 +3,10 @@
   apt_key: url=http://dl.hhvm.com/conf/hhvm.gpg.key state=present
 
 - name: Enable HHVM repo
-  apt_repository: repo="deb http://dl.hhvm.com/ubuntu {{ ansible_lsb.codename }} main" state=present
+  apt_repository: repo="deb http://dl.hhvm.com/ubuntu trusty-lts-3.12 main" state=present
 
 - name: Install HHVM
-  apt: name=hhvm state=present
+  apt: name=hhvm=3.12.1~trusty state=present
 
 - name: Do /etc/hhvm/server.ini
   template: src=etc/hhvm/server.ini dest=/etc/hhvm/server.ini owner=root group=root mode=0644


### PR DESCRIPTION
This bug fixes the issue with HHVM 3.13.0 where HHVM randomly fails by modifying the YML file for HHVM to use a working 3.12 version. Fixes #310.
