### PR TITLE
Object cache clearing on plugin change

### DIFF
--- a/provisioning/roles/wordpress/tasks/main.yml
+++ b/provisioning/roles/wordpress/tasks/main.yml
@@ -68,7 +68,7 @@
   sudo: yes
   sudo_user: "{{ web_user }}"
   ignore_errors: yes
-  register: wpnotinstalled
+  register: wpisinstalled
 
 - name: "Run the WP install for {{ enviro }}"
   command: /usr/local/bin/wp core install --url={{ domain }} --title="WP Engine {{ enviro }} Site" --admin_user=wordpress --admin_password=wordpress --admin_email="admin@example.com"
@@ -76,7 +76,7 @@
   sudo_user: "{{ web_user }}"
   args:
     chdir: "{{ wp_doc_root }}/{{ enviro }}"
-  when: wpnotinstalled.rc and ( wp.multisite|default(False) == False )
+  when: wpisinstalled|failed and ( wp.multisite|default(False) == False )
 
 - name: "Run the multisite WP subdomain install for {{ enviro }}"
   command: /usr/local/bin/wp core multisite-install --url={{ domain }} --title="WP Engine {{ enviro }} Site" --admin_user=wordpress --admin_password=wordpress --admin_email="admin@example.com" --subdomains
@@ -84,7 +84,7 @@
   sudo_user: "{{ web_user }}"
   args:
     chdir: "{{ wp_doc_root }}/{{ enviro }}"
-  when: wpnotinstalled.rc and ( wp.multisite|default(False) == "domain" )
+  when: wpisinstalled|failed and ( wp.multisite|default(False) == "domain" )
 
 - name: "Run the multisite WP subdirectory install for {{ enviro }}"
   command: /usr/local/bin/wp core multisite-install --url={{ domain }} --title="WP Engine {{ enviro }} Site" --admin_user=wordpress --admin_password=wordpress --admin_email="admin@example.com"
@@ -92,7 +92,7 @@
   sudo_user: "{{ web_user }}"
   args:
     chdir: "{{ wp_doc_root }}/{{ enviro }}"
-  when: wpnotinstalled.rc and ( wp.multisite|default(False) == "directory" )
+  when: wpisinstalled|failed and ( wp.multisite|default(False) == "directory" )
 
 - name: "Install some useful plugins for {{ enviro }}"
   command: /usr/local/bin/wp plugin install {{ item }}
@@ -100,7 +100,7 @@
   sudo_user: "{{ web_user }}"
   with_flattened:
     - "{{ wp.custom_plugins|default([]) }}"
-    - default_plugins
+    - "{{ default_plugins }}"
   args:
       chdir: "{{ wp_doc_root }}/{{ enviro }}"
       creates: "{{ wp_doc_root }}/{{ enviro }}/wp-content/plugins/{{ item }}"

--- a/provisioning/roles/wordpress/templates/wp/local-config.php
+++ b/provisioning/roles/wordpress/templates/wp/local-config.php
@@ -16,9 +16,6 @@ if (! defined('WP_CLI')) {
     define('DB_HOST', '192.168.150.20');
 }
 
-/** WP Engine Specific settings */
-define( 'WPE_ENVIRONMENT', 'developer' );
-
 /** Database Charset to use in creating database tables. */
 define('DB_CHARSET', 'utf8');
 

--- a/provisioning/roles/wordpress/templates/wp/local-config.php
+++ b/provisioning/roles/wordpress/templates/wp/local-config.php
@@ -10,7 +10,14 @@ define('DB_USER', 'wpe_{{ enviro }}');
 define('DB_PASSWORD', 'wordpress');
 
 /** MySQL hostname */
-define('DB_HOST', 'localhost');
+if (! defined('WP_CLI')) {
+    define('DB_HOST', 'localhost');
+} else {
+    define('DB_HOST', '192.168.150.20');
+}
+
+/** WP Engine Specific settings */
+define( 'WPE_ENVIRONMENT', 'developer' );
 
 /** Database Charset to use in creating database tables. */
 define('DB_CHARSET', 'utf8');

--- a/provisioning/roles/wordpress/templates/wp/object-cache.php
+++ b/provisioning/roles/wordpress/templates/wp/object-cache.php
@@ -468,3 +468,18 @@ else: // No Memcached
 	}
 
 endif;
+
+/**
+ * Workaround for bug between memcached and WP options
+ * Often, changing an option wouldn't show up until memcached is cleared
+ * This stems from an issue that get_option first uses the cached $alloptions
+ * value to find a specific option. $alloptions doesn't get flushed when plugins,
+ * themes, and other common option changes are made.
+ */
+if ( function_exists( 'wp_cache_flush' ) ) {
+	$flush_actions = ['activate_plugin', 'deactivate_plugin', 'switch_theme', 'generate_rewrite_rules'];
+
+	foreach ( $flush_actions as $action ) {
+		add_action( $action, 'wp_cache_flush' );
+	}
+}


### PR DESCRIPTION
Throwing this PR up for some initial feedback.

The HGV vagrant has issues recognizing wp_options changes when those changes are made from WP-CLI. Specifically, the object cache doesn't get cleared out. This adds onto our object cache plugin to make sure that it gets cleared out for several common tasks. (Ideally, we would clear the object cache for every object table update, but I haven't tracked down the right hook for that yet).

I also have two changes to the provisioning files.

One switches to a more Ansible-friendly method for testing whether a site has already been created (I had spotty performance with the old version as existing databases would get overwritten when I re-provision)

The other includes a modification to the wp-config.php file that defines DB_HOST as the vm's IP address, rather than local host if we're coming from a WP-CLI command.