### PR TITLE
Percona server and PML vagrant provision errors

### DIFF
--- a/provisioning/roles/admin/tasks/main.yml
+++ b/provisioning/roles/admin/tasks/main.yml
@@ -48,7 +48,7 @@
     path: "{{ wp_doc_root }}/admin/phpmemcachedadmin"
     state: absent
   when: pma_git_dir.stat.isdir is not defined
-  
+
 - name: Ensure phpMemcachedAdmin directory exists
   file:
     path: "{{ wp_doc_root }}/admin/phpmemcachedadmin"
@@ -73,7 +73,7 @@
   tags: [ 'admin', 'pimpmylog' ]
 
 - name: Download PML
-  git: repo=git://github.com/potsky/PimpMyLog.git dest={{ wp_doc_root }}/admin/logs update=no accept_hostkey=yes
+  git: repo=https://github.com/potsky/PimpMyLog.git dest={{ wp_doc_root }}/admin/logs update=no accept_hostkey=yes
   tags: [ 'admin', 'pimpmylog' ]
 
 - name: Configure PML

--- a/provisioning/roles/percona/tasks/main.yml
+++ b/provisioning/roles/percona/tasks/main.yml
@@ -17,7 +17,7 @@
   tags: [ 'percona', 'database' ]
 
 - name: Install Percona server
-  apt: name=percona-server-server-5.6 state=present
+  apt: name=percona-server-server-5.6 state=present force=yes
   notify:
     - update-rc mysql
     - mysql restart


### PR DESCRIPTION
After reading through #325, these 2 changes got me up and running on HGV. In order of errors during `vagrant up` initial hgv provision

1. append force=yes to Install Percona server apt
per #325, @adambreen:
> appears that the percona-server-5.6 package expects certain (redundant from HHGV's perspective) user input [325#issuecomment-256828142](https://github.com/wpengine/hgv/issues/325#issuecomment-256828142)
Thanks Adam!

2. PML repo git: to https: to match phpMemcachedAdmin in same file, resolves this error during install:
```
==> hgv: TASK [admin : Download PML] ****************************************************
==> hgv: fatal: [127.0.0.1]: FAILED! => {"changed": false, "cmd": "/usr/bin/git clone --origin origin git://github.com/potsky/PimpMyLog.git /nas/wp/www/sites/admin/logs", "failed": true, "msg": "Cloning into '/nas/wp/www/sites/admin/logs'...\nfatal: read error: Connection reset by peer\nfatal: early EOF\nfatal: index-pack failed", "rc": 128, "stderr": "Cloning into '/nas/wp/www/sites/admin/logs'...\nfatal: read error: Connection reset by peer\nfatal: early EOF\nfatal: index-pack failed\n", "stdout": "", "stdout_lines": []}
```

Cc @andrew40, @markkelnar, @stephen-lin, @marshalllarson, @asmartbear 