### PR TITLE
Enable codecept tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,4 +23,4 @@ test:
     override:
         - bundle exec rake spec:provision
         - bundle exec rake spec:hgv
-        - codecept run -c test/codeception/
+        - sudo codecept run -c test/codeception/

--- a/circle.yml
+++ b/circle.yml
@@ -23,3 +23,4 @@ test:
     override:
         - bundle exec rake spec:provision
         - bundle exec rake spec:hgv
+        - codecept run -c test/codeception/

--- a/test/codeception/tests/acceptance/DashboardCest.php
+++ b/test/codeception/tests/acceptance/DashboardCest.php
@@ -28,7 +28,7 @@ class DashboardCest
     {
         $I->amOnUrl('http://admin.hgv.test/phpmyadmin');
         $I->seeResponseCodeIs(200);
-        $I->see('Welcome to <bdo dir="ltr" lang="en">phpMyAdmin</bdo>');
+        $I->see('Welcome to phpMyAdmin');
     }
 
     public function viewPhpmemcachedadmin(AcceptanceTester $I)

--- a/test/codeception/tests/acceptance/DefaultWPCest.php
+++ b/test/codeception/tests/acceptance/DefaultWPCest.php
@@ -138,6 +138,7 @@ class DefaultWPCest
         $I->amOnPage('/test-error-500.php');
         $I->seeResponseCodeIs(500);
         $I->seeCurrentUrlEquals('/test-error-500.php');
+        $I->see('You are seeing this because you are using the PHP selector, and the page you are working on just returned an error.');
 
         $I->deleteFile($file);
     }

--- a/test/codeception/tests/acceptance/MultisiteDirectoryCest.php
+++ b/test/codeception/tests/acceptance/MultisiteDirectoryCest.php
@@ -11,7 +11,9 @@ class MultisiteDirectoryCest
     {
     }
 
-    // tests
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPageHHVM(AcceptanceTester $I)
     {
         $I->amOnUrl('http://multidirectory.test');
@@ -20,6 +22,9 @@ class MultisiteDirectoryCest
         $I->seeResponseCodeIs(200);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewSubpageHHVM(AcceptanceTester $I)
     {
         $I->amOnUrl('http://multidirectory.test');
@@ -29,6 +34,9 @@ class MultisiteDirectoryCest
         $I->seeResponseCodeIs(200);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPagePHP(AcceptanceTester $I)
     {
         // Pass header/cookie to specify the backend
@@ -38,6 +46,9 @@ class MultisiteDirectoryCest
         $I->seeResponseCodeIs(200);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPagePHP7(AcceptanceTester $I)
     {
         // Pass header/cookie to specify the backend
@@ -47,6 +58,9 @@ class MultisiteDirectoryCest
         $I->seeResponseCodeIs(200);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewSubpagePHP(AcceptanceTester $I)
     {
         // Pass header/cookie to specify the backend
@@ -58,6 +72,9 @@ class MultisiteDirectoryCest
         $I->seeResponseCodeIs(200);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewSubpagePHP7(AcceptanceTester $I)
     {
         // Pass header/cookie to specify the backend
@@ -69,6 +86,9 @@ class MultisiteDirectoryCest
         $I->seeResponseCodeIs(200);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPageHHVM404(AcceptanceTester $I)
     {
         $I->amOnUrl('http://multidirectory.test');
@@ -76,6 +96,9 @@ class MultisiteDirectoryCest
         $I->seeResponseCodeIs(404);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPagePHP404(AcceptanceTester $I)
     {
         // Pass header/cookie to specify the backend
@@ -86,6 +109,9 @@ class MultisiteDirectoryCest
         $I->seeResponseCodeIs(404);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPagePHP7_404(AcceptanceTester $I)
     {
         // Pass header/cookie to specify the backend

--- a/test/codeception/tests/acceptance/MultisiteDomainCest.php
+++ b/test/codeception/tests/acceptance/MultisiteDomainCest.php
@@ -11,7 +11,9 @@ class MultisiteDomainCest
     {
     }
 
-    // tests
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPageHHVM(AcceptanceTester $I)
     {
         $I->amOnUrl('http://multidomain.test');
@@ -20,6 +22,9 @@ class MultisiteDomainCest
         $I->seeResponseCodeIs(200);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPagePHP(AcceptanceTester $I)
     {
         $I->amOnUrl('http://php.multidomain.test');
@@ -28,6 +33,9 @@ class MultisiteDomainCest
         $I->seeResponseCodeIs(200);
     }
 
+    /**
+     * @incomplete Multisite tests not implemented yet.
+     */
     public function viewPageHHVM404(AcceptanceTester $I)
     {
         $I->amOnUrl('http://multidomain.test');


### PR DESCRIPTION
I wrote some functional and acceptance tests using codeception test framework.  This PR is to enable those to run in circleci.

Also flagged some of those tests that are specific to multisite testing as incomplete.  These will be noted as such with the tests run, but will not error or fail the test run.