### PR TITLE
Update the S3 Uploads plugin

### DIFF
--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -34,5 +34,5 @@ default_plugins:
   - log-deprecated-notices
 
 default_repo_plugins:
-  - slug: S3-Uploads-0.9.0
-    url: "https://github.com/humanmade/S3-Uploads/archive/v0.9.0.zip"
+  - slug: S3-Uploads-1.1.0
+    url: "https://codeload.github.com/humanmade/S3-Uploads/zip/v1.1.0"


### PR DESCRIPTION
The ZIP file location provided by GitHub isn't to the actual file,
but redirects to a CDN-hosted file stream. This causes provisioning
to throw an error about the file not existing, resulting in the plugin
not getting installed on sites as intended. This fixes that by using the
CDN URL to the filestream.

This also bumps the version to the latest release of 1.1.0.

Fixes #355. 