### PR TITLE
Bump WP-CLI to 1.2.0 (latest) release

### DIFF
--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -6,7 +6,7 @@ nginx_listen_port_http_to_fcgi: 8083
 
 varnish_version: 3.0
 phpmyadmin_version: 4.3.6-english
-wpcli_version: WP-CLI 0.18
+wpcli_version: WP-CLI 1.2.0
 wp_doc_root: /nas/wp/www/sites
 vagrant_doc_root: /hgv_data/sites
 web_user: www-data


### PR DESCRIPTION
WP-CLI 1.2.0 was just released yesterday, so I figured it'd be good to use it.