### PR TITLE
Fix typo in WP local config template

### DIFF
--- a/provisioning/roles/wordpress/templates/wp/local-config.php
+++ b/provisioning/roles/wordpress/templates/wp/local-config.php
@@ -23,7 +23,7 @@ define('WP_DEBUG_DISPLAY', false);
 define('SCRIPT_DEBUG', true);
 define('SAVEQUERIES', true);
 
-global $memecached_servers;
+global $memcached_servers;
 
 $memcached_servers = array(
     'default' => array(


### PR DESCRIPTION
Memes are fun, but not when caching. 😺 