### PR TITLE
Enable short_code_tag for PHP cli

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,4 +23,4 @@ test:
     override:
         - bundle exec rake spec:provision
         - bundle exec rake spec:hgv
-        - sudo codecept run -c test/codeception/
+        - sudo /usr/bin/php7.0 /usr/local/bin/codecept run -c test/codeception/

--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -89,11 +89,11 @@
 - include: php71.yml
 
 # Set the alternatives deliberately, so that 5.6 or 7.0 doesn't override
-- name: Set PHP 5.5 bin as default
-  alternatives: name=php link=/usr/bin/php path=/usr/bin/php5
+- name: Set PHP 5.6 bin as default
+  alternatives: name=php link=/usr/bin/php path=/usr/bin/php5.6
 
-- name: Set PHP 5.5 config as default
-  alternatives: name=php-config link=/usr/bin/php-config path=/usr/bin/php-config5
+- name: Set PHP 5.6 config as default
+  alternatives: name=php-config link=/usr/bin/php-config path=/usr/bin/php-config5.6
 
-- name: Set PHP 5.5 ize as default
-  alternatives: name=phpize link=/usr/bin/phpize path=/usr/bin/phpize5
+- name: Set PHP 5.6 ize as default
+  alternatives: name=phpize link=/usr/bin/phpize path=/usr/bin/phpize5.6

--- a/provisioning/roles/php-fpm/tasks/main.yml
+++ b/provisioning/roles/php-fpm/tasks/main.yml
@@ -75,6 +75,15 @@
     - upload_max_filesize
     - post_max_size
 
+- name: Set values in php.ini cli
+  ini_file:
+    dest: /etc/php5/cli/php.ini
+    section: "PHP"
+    option: "{{ item.name }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { name: 'short_open_tag', value: 'On' }
+
 - include: php56.yml
 - include: php70.yml
 - include: php71.yml

--- a/provisioning/roles/php-fpm/tasks/php56.yml
+++ b/provisioning/roles/php-fpm/tasks/php56.yml
@@ -15,6 +15,7 @@
       - php5.6-json
       - php5.6-opcache
       - php5.6-mysql
+      - php5.6-xml
       - php-memcached
       - php-xdebug
 
@@ -33,3 +34,12 @@
   with_items:
     - upload_max_filesize
     - post_max_size
+
+- name: Set 5.6 values in php.ini cli
+  ini_file:
+    dest: /etc/php/5.6/cli/php.ini
+    section: "PHP"
+    option: "{{ item.name }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { name: 'short_open_tag', value: 'On' }

--- a/provisioning/roles/php-fpm/tasks/php70.yml
+++ b/provisioning/roles/php-fpm/tasks/php70.yml
@@ -15,6 +15,7 @@
       - php7.0-json
       - php7.0-opcache
       - php7.0-mysql
+      - php7.0-xml
       - php-memcached
       - php-xdebug
 
@@ -33,3 +34,12 @@
   with_items:
     - upload_max_filesize
     - post_max_size
+
+- name: Set 7.0 values in php.ini cli
+  ini_file:
+    dest: /etc/php/7.0/cli/php.ini
+    section: "PHP"
+    option: "{{ item.name }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { name: 'short_open_tag', value: 'On' }

--- a/provisioning/roles/php-fpm/tasks/php71.yml
+++ b/provisioning/roles/php-fpm/tasks/php71.yml
@@ -15,6 +15,7 @@
       - php7.1-json
       - php7.1-opcache
       - php7.1-mysql
+      - php7.1-xml
       - php-memcached
       - php-xdebug
 
@@ -33,3 +34,12 @@
   with_items:
     - upload_max_filesize
     - post_max_size
+
+- name: Set 7.1 values in php.ini cli
+  ini_file:
+    dest: /etc/php/7.1/cli/php.ini
+    section: "PHP"
+    option: "{{ item.name }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { name: 'short_open_tag', value: 'On' }

--- a/test/codeception/tests/acceptance/BackendCookieCest.php
+++ b/test/codeception/tests/acceptance/BackendCookieCest.php
@@ -1,5 +1,4 @@
 <?php
-use \AcceptanceTester;
 
 class BackendCookieCest
 {

--- a/test/codeception/tests/acceptance/DashboardCest.php
+++ b/test/codeception/tests/acceptance/DashboardCest.php
@@ -1,5 +1,4 @@
 <?php
-use \AcceptanceTester;
 
 class DashboardCest
 {

--- a/test/codeception/tests/acceptance/DefaultWPCest.php
+++ b/test/codeception/tests/acceptance/DefaultWPCest.php
@@ -1,5 +1,4 @@
 <?php
-use \AcceptanceTester;
 
 // TODO: These tests are duplicate for hhvm and php. Probably a good idea to refactor these tests so there is one set of tests and each domain endpoint is extended to call the test suite.
 class DefaultWPCest

--- a/test/codeception/tests/acceptance/ErrorPageCest.php
+++ b/test/codeception/tests/acceptance/ErrorPageCest.php
@@ -1,5 +1,4 @@
 <?php
-use \AcceptanceTester;
 
 class ErrorPageCest
 {

--- a/test/codeception/tests/acceptance/MultisiteDirectoryCest.php
+++ b/test/codeception/tests/acceptance/MultisiteDirectoryCest.php
@@ -1,5 +1,4 @@
 <?php
-use \AcceptanceTester;
 
 class MultisiteDirectoryCest
 {

--- a/test/codeception/tests/acceptance/MultisiteDomainCest.php
+++ b/test/codeception/tests/acceptance/MultisiteDomainCest.php
@@ -1,5 +1,4 @@
 <?php
-use \AcceptanceTester;
 
 class MultisiteDomainCest
 {

--- a/test/codeception/tests/acceptance/UploadSizeCest.php
+++ b/test/codeception/tests/acceptance/UploadSizeCest.php
@@ -1,5 +1,4 @@
 <?php
-use \AcceptanceTester;
 
 class UploadSizeWPCest
 {

--- a/test/codeception/tests/acceptance/VarnishCest.php
+++ b/test/codeception/tests/acceptance/VarnishCest.php
@@ -1,5 +1,4 @@
 <?php
-use \AcceptanceTester;
 
 class VarnishCest
 {


### PR DESCRIPTION
I think this will fix failing circle ci test specific to codeception.