### PR TITLE
Update varnish apt-repo configuration

### DIFF
--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -5,6 +5,7 @@ varnish_listen_port: 6081
 nginx_listen_port_http_to_fcgi: 8083
 
 varnish_version: 3.0
+varnish_packagecloud_repo: "varnish{{ varnish_version|replace('.', '') }}"
 phpmyadmin_version: 4.3.6-english
 wpcli_version: WP-CLI 1.2.0
 wp_doc_root: /nas/wp/www/sites

--- a/provisioning/roles/varnish/tasks/main.yml
+++ b/provisioning/roles/varnish/tasks/main.yml
@@ -1,10 +1,18 @@
 ---
+- name: Ensure APT HTTPS Transport is installed.
+  apt:
+    name: apt-transport-https
+    state: installed
 
-- name: Fill the varnish GPG Key
-  apt_key: data="{{ lookup('file', '../files/varnish-cache.gpg.key') }}"
+- name: Add packagecloud.io Varnish apt key.
+  apt_key:
+    url: https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/gpgkey
+    state: present
 
-- name: Add the varnish cache repo file
-  apt_repository: repo='deb http://repo.varnish-cache.org/ubuntu/ {{ ansible_lsb.codename }} varnish-{{ varnish_version }}' state=present update_cache=yes
+- name: Add packagecloud.io Varnish apt repository.
+  apt_repository:
+    repo: "deb https://packagecloud.io/varnishcache/{{ varnish_packagecloud_repo }}/ubuntu/ {{ ansible_lsb.codename }} main"
+    state: present
 
 - name: Install Varnish
   apt: name=varnish state=present
@@ -23,4 +31,4 @@
   notify: varnishncsa reload
 
 - name: Ensure Varnish is running
-  service: name=varnish state=running
+  service: name=varnish state=started


### PR DESCRIPTION
Should address issue #367 

@kyasui was correct that the Varnish repo has moved over to packagecloud.io, so the varnish default tasks needed to be updated accordingly.